### PR TITLE
Damage stats

### DIFF
--- a/agent/pokemon_agent.py
+++ b/agent/pokemon_agent.py
@@ -2,7 +2,7 @@
 
 from numpy.random import uniform
 from agent.base_agent import BaseAgent
-
+from pokemon.damage_stats import DamageStatCalc
 
 class PokemonAgent(BaseAgent):
     """Class for a pokemon player."""
@@ -18,6 +18,7 @@ class PokemonAgent(BaseAgent):
         self.opp_gamestate = {}
         self.opp_gamestate["data"] = {}
         self.opp_gamestate["moves"] = {}
+        self.dmg_stat_calc = DamageStatCalc()
 
     def reset_gamestates(self):
         """Reset gamestate values for a new battle."""

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -52,3 +52,22 @@ class DamageStatCalc():
         self.damage_stats[230] = 23.62
         self.damage_stats[250] = 25.52
         self.damage_stats[255] = 260
+
+    def estimate_dmg_val(self, stat_val, is_hp = False, is_atk = False, max_evs = False):
+        """Estimate the value of a damage_statistic."""
+        dmg_val = None
+        if stat_val in self.damage_stats:
+            dmg_val = self.damage_stats[stat_val]
+        else:
+            # IMPLEMENT ME LATER
+            pass
+        
+        if is_hp:
+            dmg_val = dmg_val + 5
+        elif is_atk:
+            if max_evs:
+                dmg_val += 3
+
+            dmg_val = dmg_val * 4
+
+        return dmg_val

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -1,0 +1,54 @@
+"""
+Class for calculating damage stats for a pokemon.
+
+Based on https://www.smogon.com/smog/issue4/damage_stats
+"""
+
+class DamageStatCalc():
+    """The class to do the thing."""
+
+    def __init__(self):
+        """Initialize the calculator."""
+        self.damage_stats = {}
+    
+    def build_stats(self):
+        """Build the dictionary for the stat numbers."""
+        self.damage_stats[5] = 2.19
+        self.damage_stats[10] = 2.67
+        self.damage_stats[15] = 3.14
+        self.damage_stats[20] = 3.62
+        self.damage_stats[25] = 4.10
+        self.damage_stats[30] = 4.57
+        self.damage_stats[35] = 5.05
+        self.damage_stats[40] = 5.52
+        self.damage_stats[45] = 6.00
+        self.damage_stats[50] = 6.48
+        self.damage_stats[55] = 6.95
+        self.damage_stats[60] = 7.43
+        self.damage_stats[65] = 7.90
+        self.damage_stats[70] = 8.38
+        self.damage_stats[75] = 8.86
+        self.damage_stats[80] = 9.33
+        self.damage_stats[85] = 9.81
+        self.damage_stats[90] = 10.29
+        self.damage_stats[95] = 10.76
+        self.damage_stats[100] = 11.24
+        self.damage_stats[105] = 11.71
+        self.damage_stats[110] = 12.19
+        self.damage_stats[115] = 12.67
+        self.damage_stats[120] = 13.14
+        self.damage_stats[125] = 13.62
+        self.damage_stats[130] = 14.10
+        self.damage_stats[135] = 14.57
+        self.damage_stats[140] = 15.05
+        self.damage_stats[145] = 15.52
+        self.damage_stats[150] = 16.00
+        self.damage_stats[160] = 16.95
+        self.damage_stats[165] = 17.43
+        self.damage_stats[170] = 17.90
+        self.damage_stats[180] = 18.86
+        self.damage_stats[190] = 19.81
+        self.damage_stats[200] = 20.76
+        self.damage_stats[230] = 23.62
+        self.damage_stats[250] = 25.52
+        self.damage_stats[255] = 260

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -4,6 +4,7 @@ Class for calculating damage stats for a pokemon.
 Based on https://www.smogon.com/smog/issue4/damage_stats
 """
 
+from math import inf
 
 class DamageStatCalc():
     """The class to do the thing."""
@@ -78,5 +79,23 @@ class DamageStatCalc():
         """Find the closest value in the keys to this number"""
         closest_num = None
         offset = None
+        values = self.damage_stats.keys()
+
+        if number < values[0]:
+            return values[0]
+
+        differences = [number - val for val in values]
+
+        smallest_diff_ind = None
+        smallest_diff = inf
+        index = 0
+        for diff in differences:
+            if diff < smallest_diff:
+                smallest_diff = diff
+                smallest_diff_ind = index
+            index += 1
+        
+        closest_num = values[smallest_diff_ind]
+        offset = smallest_diff
 
         return closest_num, offset

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -65,7 +65,7 @@ class DamageStatCalc():
         else:
             closest_num, offset = self.find_closest_level(stat_val)
             dmg_val = self.damage_stats[closest_num]
-            dmg_val += 0.19*offset
+            dmg_val += 0.19*offset/2
 
         if is_hp:
             dmg_val = dmg_val + 5
@@ -74,6 +74,10 @@ class DamageStatCalc():
                 dmg_val += 3
 
             dmg_val = dmg_val * 4
+
+        # Hacky way to get around the .499999
+        # not rounding properly.
+        dmg_val = round(round(dmg_val, 3), 2)
 
         return dmg_val
 

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -6,12 +6,14 @@ Based on https://www.smogon.com/smog/issue4/damage_stats
 
 from math import inf
 
+
 class DamageStatCalc():
     """The class to do the thing."""
 
     def __init__(self):
         """Initialize the calculator."""
         self.damage_stats = {}
+        self.build_stats()
 
     def build_stats(self):
         """Build the dictionary for the stat numbers."""
@@ -76,13 +78,17 @@ class DamageStatCalc():
         return dmg_val
 
     def find_closest_level(self, number):
-        """Find the closest value in the keys to this number"""
+        """
+        Find the closest value in the keys to this number.
+
+        Rounds down, so 215 mathces to 200.
+        """
         closest_num = None
         offset = None
-        values = self.damage_stats.keys()
+        values = list(self.damage_stats.keys())
 
         if number < values[0]:
-            return values[0]
+            return values[0], number - values[0]
 
         differences = [number - val for val in values]
 
@@ -90,11 +96,11 @@ class DamageStatCalc():
         smallest_diff = inf
         index = 0
         for diff in differences:
-            if diff < smallest_diff:
+            if abs(diff) < smallest_diff:
                 smallest_diff = diff
                 smallest_diff_ind = index
             index += 1
-        
+
         closest_num = values[smallest_diff_ind]
         offset = smallest_diff
 

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -15,47 +15,9 @@ class DamageStatCalc():
         self.damage_stats = {}
         self.build_stats()
 
-    def build_stats(self):
-        """Build the dictionary for the stat numbers."""
-        self.damage_stats[5] = 2.19
-        self.damage_stats[10] = 2.67
-        self.damage_stats[15] = 3.14
-        self.damage_stats[20] = 3.62
-        self.damage_stats[25] = 4.10
-        self.damage_stats[30] = 4.57
-        self.damage_stats[35] = 5.05
-        self.damage_stats[40] = 5.52
-        self.damage_stats[45] = 6.00
-        self.damage_stats[50] = 6.48
-        self.damage_stats[55] = 6.95
-        self.damage_stats[60] = 7.43
-        self.damage_stats[65] = 7.90
-        self.damage_stats[70] = 8.38
-        self.damage_stats[75] = 8.86
-        self.damage_stats[80] = 9.33
-        self.damage_stats[85] = 9.81
-        self.damage_stats[90] = 10.29
-        self.damage_stats[95] = 10.76
-        self.damage_stats[100] = 11.24
-        self.damage_stats[105] = 11.71
-        self.damage_stats[110] = 12.19
-        self.damage_stats[115] = 12.67
-        self.damage_stats[120] = 13.14
-        self.damage_stats[125] = 13.62
-        self.damage_stats[130] = 14.10
-        self.damage_stats[135] = 14.57
-        self.damage_stats[140] = 15.05
-        self.damage_stats[145] = 15.52
-        self.damage_stats[150] = 16.00
-        self.damage_stats[160] = 16.95
-        self.damage_stats[165] = 17.43
-        self.damage_stats[170] = 17.90
-        self.damage_stats[180] = 18.86
-        self.damage_stats[190] = 19.81
-        self.damage_stats[200] = 20.76
-        self.damage_stats[230] = 23.62
-        self.damage_stats[250] = 25.52
-        self.damage_stats[255] = 260
+    def calculate_range(self, attacker, defender, move):
+        """Calculate the damage range for a player's attack."""
+        pass
 
     def estimate_dmg_val(self, stat_val, **kwargs):
         """Estimate the value of a damage_statistic."""
@@ -117,3 +79,45 @@ class DamageStatCalc():
         offset = smallest_diff
 
         return closest_num, offset
+
+    def build_stats(self):
+        """Build the dictionary for the stat numbers."""
+        self.damage_stats[5] = 2.19
+        self.damage_stats[10] = 2.67
+        self.damage_stats[15] = 3.14
+        self.damage_stats[20] = 3.62
+        self.damage_stats[25] = 4.10
+        self.damage_stats[30] = 4.57
+        self.damage_stats[35] = 5.05
+        self.damage_stats[40] = 5.52
+        self.damage_stats[45] = 6.00
+        self.damage_stats[50] = 6.48
+        self.damage_stats[55] = 6.95
+        self.damage_stats[60] = 7.43
+        self.damage_stats[65] = 7.90
+        self.damage_stats[70] = 8.38
+        self.damage_stats[75] = 8.86
+        self.damage_stats[80] = 9.33
+        self.damage_stats[85] = 9.81
+        self.damage_stats[90] = 10.29
+        self.damage_stats[95] = 10.76
+        self.damage_stats[100] = 11.24
+        self.damage_stats[105] = 11.71
+        self.damage_stats[110] = 12.19
+        self.damage_stats[115] = 12.67
+        self.damage_stats[120] = 13.14
+        self.damage_stats[125] = 13.62
+        self.damage_stats[130] = 14.10
+        self.damage_stats[135] = 14.57
+        self.damage_stats[140] = 15.05
+        self.damage_stats[145] = 15.52
+        self.damage_stats[150] = 16.00
+        self.damage_stats[160] = 16.95
+        self.damage_stats[165] = 17.43
+        self.damage_stats[170] = 17.90
+        self.damage_stats[180] = 18.86
+        self.damage_stats[190] = 19.81
+        self.damage_stats[200] = 20.76
+        self.damage_stats[230] = 23.62
+        self.damage_stats[250] = 25.52
+        self.damage_stats[255] = 260

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -57,7 +57,7 @@ class DamageStatCalc():
         self.damage_stats[250] = 25.52
         self.damage_stats[255] = 260
 
-    def estimate_dmg_val(self, stat_val, is_hp=False, is_atk=False, max_evs=False):
+    def estimate_dmg_val(self, stat_val, is_hp=False, is_atk=False, max_evs=False, positive_nature=False):
         """Estimate the value of a damage_statistic."""
         dmg_val = None
         if stat_val in self.damage_stats:
@@ -74,6 +74,9 @@ class DamageStatCalc():
                 dmg_val += 3
 
             dmg_val = dmg_val * 4
+
+        if positive_nature:
+            dmg_val *= 1.1
 
         # Hacky way to get around the .499999
         # not rounding properly.

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -57,8 +57,13 @@ class DamageStatCalc():
         self.damage_stats[250] = 25.52
         self.damage_stats[255] = 260
 
-    def estimate_dmg_val(self, stat_val, is_hp=False, is_atk=False, max_evs=False, positive_nature=False):
+    def estimate_dmg_val(self, stat_val, **kwargs):
         """Estimate the value of a damage_statistic."""
+        is_hp = kwargs.get("is_hp", False)
+        is_atk = kwargs.get("is_atk", False)
+        max_evs = kwargs.get("max_evs", False)
+        positive_nature = kwargs.get("positive_nature", False)
+
         dmg_val = None
         if stat_val in self.damage_stats:
             dmg_val = self.damage_stats[stat_val]

--- a/pokemon/damage_stats.py
+++ b/pokemon/damage_stats.py
@@ -4,13 +4,14 @@ Class for calculating damage stats for a pokemon.
 Based on https://www.smogon.com/smog/issue4/damage_stats
 """
 
+
 class DamageStatCalc():
     """The class to do the thing."""
 
     def __init__(self):
         """Initialize the calculator."""
         self.damage_stats = {}
-    
+
     def build_stats(self):
         """Build the dictionary for the stat numbers."""
         self.damage_stats[5] = 2.19
@@ -53,15 +54,16 @@ class DamageStatCalc():
         self.damage_stats[250] = 25.52
         self.damage_stats[255] = 260
 
-    def estimate_dmg_val(self, stat_val, is_hp = False, is_atk = False, max_evs = False):
+    def estimate_dmg_val(self, stat_val, is_hp=False, is_atk=False, max_evs=False):
         """Estimate the value of a damage_statistic."""
         dmg_val = None
         if stat_val in self.damage_stats:
             dmg_val = self.damage_stats[stat_val]
         else:
-            # IMPLEMENT ME LATER
-            pass
-        
+            closest_num, offset = self.find_closest_level(stat_val)
+            dmg_val = self.damage_stats[closest_num]
+            dmg_val += 0.19*offset
+
         if is_hp:
             dmg_val = dmg_val + 5
         elif is_atk:
@@ -71,3 +73,10 @@ class DamageStatCalc():
             dmg_val = dmg_val * 4
 
         return dmg_val
+
+    def find_closest_level(self, number):
+        """Find the closest value in the keys to this number"""
+        closest_num = None
+        offset = None
+
+        return closest_num, offset

--- a/tests/agent_tests/pokemon_agent_test.py
+++ b/tests/agent_tests/pokemon_agent_test.py
@@ -84,7 +84,7 @@ def test_switch_faint():
     assert val in range(3)
 
 
-def test_battle_posn():
+def test_battle_posn_one():
     """Test battle position functions work."""
     magikarp = Pokemon(name="magikarp", moves=["tackle"])
     magikarp_opp = Pokemon(name="magikarp", moves=["tackle"])
@@ -121,7 +121,52 @@ def test_battle_posn():
     assert pa1.battle_position() > 1
 
 
+def test_battle_posn_multiple():
+    """Test that battle position functions work with multiple pokemon."""
+    magikarp = Pokemon(name="magikarp", moves=["tackle"])
+    magikarp_opp = Pokemon(name="magikarp", moves=["tackle"])
+    spinda = Pokemon(name="spinda", moves=["tackle"])
+
+    pa1 = PokemonAgent([magikarp, spinda, spinda])
+
+    gamestate = {}
+    gamestate["team"] = [spinda, spinda]
+    gamestate["active"] = magikarp
+
+    opp_gamestate_dict = {}
+    opp_gamestate_dict["team"] = [spinda]
+    opp_gamestate_dict["active"] = magikarp_opp
+    opp_gamestate = anonymize_gamestate_helper(opp_gamestate_dict)
+
+    # Everything maximum HP
+    pa1.update_gamestate(gamestate, opp_gamestate)
+    assert pa1.calc_position() == 3
+    assert pa1.calc_opp_position() == 2
+    assert pa1.battle_position() == 1.5
+
+    # Good position, opponent has low HP
+    magikarp_opp.current_hp = 1
+    opp_gamestate = anonymize_gamestate_helper(opp_gamestate_dict)
+    pa1.update_gamestate(gamestate, opp_gamestate)
+    assert pa1.calc_position() == 3
+    assert pa1.calc_opp_position() < 2
+    assert pa1.calc_opp_position() > 1
+    assert pa1.battle_position() > 1.5
+    assert pa1.battle_position() < 3
+
+    # Bad position, we have low HP
+    magikarp_opp.current_hp = magikarp_opp.max_hp
+    magikarp.current_hp = 1
+    opp_gamestate = anonymize_gamestate_helper(opp_gamestate_dict)
+    pa1.update_gamestate(gamestate, opp_gamestate)
+    assert pa1.calc_position() < 3
+    assert pa1.calc_position() > 2
+    assert pa1.calc_opp_position() == 2
+    assert pa1.battle_position() < 1.5
+    assert pa1.calc_position() > 1
+
 test_make_move()
 test_opp_gamestate()
 test_switch_faint()
-test_battle_posn()
+test_battle_posn_one()
+test_battle_posn_multiple()

--- a/tests/agent_tests/pokemon_agent_test.py
+++ b/tests/agent_tests/pokemon_agent_test.py
@@ -165,6 +165,7 @@ def test_battle_posn_multiple():
     assert pa1.battle_position() < 1.5
     assert pa1.calc_position() > 1
 
+
 test_make_move()
 test_opp_gamestate()
 test_switch_faint()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -56,8 +56,8 @@ def test_run_multiple_pokemon():
 def test_run_multiple_moves():
     """Test running a game with multiple moves."""
     exploud = Pokemon(name="exploud", moves=["shadowball"])
-    spinda = Pokemon(name="spinda", moves=[
-                     "watergun", "tackle", "thundershock"])
+    spinda = Pokemon(name="spinda",
+                     moves=["watergun", "tackle", "thundershock"])
 
     player1 = PokemonAgent([exploud])
     player2 = PokemonAgent([spinda])

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -6,10 +6,12 @@ from battle_engine.pokemon_engine import PokemonEngine
 
 
 def suppress_print():
+    """Suppress print from PokemonEngine."""
     import os
     import sys
     f = open(os.devnull, 'w')
     sys.stdout = f
+
 
 def test_run():
     """Test running of a pokemon game."""
@@ -54,7 +56,8 @@ def test_run_multiple_pokemon():
 def test_run_multiple_moves():
     """Test running a game with multiple moves."""
     exploud = Pokemon(name="exploud", moves=["shadowball"])
-    spinda = Pokemon(name="spinda", moves=["watergun", "tackle", "thundershock"])
+    spinda = Pokemon(name="spinda", moves=[
+                     "watergun", "tackle", "thundershock"])
 
     player1 = PokemonAgent([exploud])
     player2 = PokemonAgent([spinda])
@@ -75,6 +78,7 @@ def test_run_infinite():
     p_eng.run(player1, player2)
     # We got to the turn limit
     assert p_eng.game_state["num_turns"] > p_eng.turn_limit
+
 
 suppress_print()
 test_run()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -26,7 +26,8 @@ def test_estimate_dmg_val():
     assert dsc.estimate_dmg_val(144, is_hp=True) == 20.43
     assert dsc.estimate_dmg_val(88, is_atk=True) == 40.4
     assert dsc.estimate_dmg_val(150, is_atk=True, max_evs=True, positive_nature=True) == 83.6
-
+    assert dsc.estimate_dmg_val(90, is_hp=True) == 15.29
+    assert dsc.estimate_dmg_val(120) == 13.14
 
 test_init()
 test_nearest_num()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -7,4 +7,13 @@ def test_init():
     dsc = DamageStatCalc()
     assert dsc.damage_stats
 
+def test_nearest_num():
+    """Make sure it calculates the nearest number properly."""
+    dsc = DamageStatCalc()
+
+    assert dsc.find_closest_level(4) == (5, -1)
+    assert dsc.find_closest_level(215) == (200, 15)
+    assert dsc.find_closest_level(17) == (15, 2)
+
 test_init()
+test_nearest_num()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -1,8 +1,10 @@
 """Unit tests for damage_stats calculator."""
 
+from pokemon.damage_stats import DamageStatCalc
 
 def test_init():
     """Make sure everything initializes properly."""
-    pass
+    dsc = DamageStatCalc()
+    assert dsc.damage_stats
 
 test_init()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -25,6 +25,7 @@ def test_estimate_dmg_val():
     assert dsc.estimate_dmg_val(77) == 9.05
     assert dsc.estimate_dmg_val(144, is_hp=True) == 20.43
     assert dsc.estimate_dmg_val(88, is_atk=True) == 40.4
+    assert dsc.estimate_dmg_val(150, is_atk=True, max_evs=True, positive_nature=True) == 83.6
 
 
 test_init()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -2,10 +2,12 @@
 
 from pokemon.damage_stats import DamageStatCalc
 
+
 def test_init():
     """Make sure everything initializes properly."""
     dsc = DamageStatCalc()
     assert dsc.damage_stats
+
 
 def test_nearest_num():
     """Make sure it calculates the nearest number properly."""
@@ -15,5 +17,16 @@ def test_nearest_num():
     assert dsc.find_closest_level(215) == (200, 15)
     assert dsc.find_closest_level(17) == (15, 2)
 
+
+def test_estimate_dmg_val():
+    """Test calculation of stats."""
+    dsc = DamageStatCalc()
+
+    assert dsc.estimate_dmg_val(77) == 9.05
+    assert dsc.estimate_dmg_val(144, is_hp=True) == 20.43
+    assert dsc.estimate_dmg_val(88, is_atk=True) == 40.4
+
+
 test_init()
 test_nearest_num()
+test_estimate_dmg_val()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -1,0 +1,8 @@
+"""Unit tests for damage_stats calculator."""
+
+
+def test_init():
+    """Make sure everything initializes properly."""
+    pass
+
+test_init()

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -25,9 +25,13 @@ def test_estimate_dmg_val():
     assert dsc.estimate_dmg_val(77) == 9.05
     assert dsc.estimate_dmg_val(144, is_hp=True) == 20.43
     assert dsc.estimate_dmg_val(88, is_atk=True) == 40.4
-    assert dsc.estimate_dmg_val(150, is_atk=True, max_evs=True, positive_nature=True) == 83.6
+    assert dsc.estimate_dmg_val(150,
+                                is_atk=True,
+                                max_evs=True,
+                                positive_nature=True) == 83.6
     assert dsc.estimate_dmg_val(90, is_hp=True) == 15.29
     assert dsc.estimate_dmg_val(120) == 13.14
+
 
 test_init()
 test_nearest_num()


### PR DESCRIPTION
Adds Damage Stats for approximating damage calculations (without needing to give each agent access to a game_engine of their own). This will only be used by agents in their internal methods.

Also adds more tests for inferring battle position when multiple pokemon are involved.

Addresses #33 