### PR TITLE
Log turn info

### DIFF
--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -448,8 +448,8 @@ def init_player_logwriter(player1, player2):
     """Initialize the log writer to write the turns of this game."""
     header = ["turn_num", "player_id", "active", "target", "move", "damage"]
     turn_logwriter = LogWriter(header, prefix="PKMNGame_{}_{}_{}".format(
-        player1.id,
-        player2.id,
+        player1.type,
+        player2.type,
         uuid4()))
 
     return turn_logwriter

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -81,7 +81,7 @@ class PokemonEngine():
                                                       player2_move,
                                                       player1,
                                                       player2)
-            log_turn(turn_logwriter, turn_info)
+            self.log_turn(turn_logwriter, turn_info)
 
         if outcome["draw"]:
             # It was a draw, decide randomly
@@ -355,6 +355,18 @@ class PokemonEngine():
         player2.update_gamestate(
             self.game_state["player2"], self.anonymize_gamestate("player1"))
 
+    def log_turn(self, turn_logwriter, turn_info):
+        """Log the information from this turn."""
+        for turn in turn_info:
+            new_row = []
+            new_row.append(self.game_state["num_turns"])
+            new_row.append(turn["attacker"])
+            new_row.append(self.game_state[turn["attacker"]]["active"])
+            new_row.append(self.game_state[turn["defender"]]["active"])
+            new_row.append(turn["move"]["name"])
+            new_row.append(turn["damage"])
+            turn_logwriter.write_line(new_row)
+
 
 def anonymize_gamestate_helper(data):
     """Anonymize some gamestate data."""
@@ -434,14 +446,10 @@ def calculate_modifier(move, attacker, defender):
 
 def init_player_logwriter(player1, player2):
     """Initialize the log writer to write the turns of this game."""
-    header = ["turn_num", "player_id", "active", "move"]
+    header = ["turn_num", "player_id", "active", "target", "move", "damage"]
     turn_logwriter = LogWriter(header, prefix="PKMNGame_{}_{}_{}".format(
         player1.id,
         player2.id,
         uuid4()))
 
     return turn_logwriter
-
-def log_turn(turn_logwriter, turn_info):
-    """Log the information from this turn."""
-    pass

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -77,8 +77,11 @@ class PokemonEngine():
             player1_move = player1.make_move()
             player2_move = player2.make_move()
 
-            outcome = self.run_single_turn(
-                player1_move, player2_move, player1, player2)[0]
+            outcome, turn_info = self.run_single_turn(player1_move,
+                                                      player2_move,
+                                                      player1,
+                                                      player2)
+            log_turn(turn_logwriter, turn_info)
 
         if outcome["draw"]:
             # It was a draw, decide randomly
@@ -438,3 +441,7 @@ def init_player_logwriter(player1, player2):
         uuid4()))
 
     return turn_logwriter
+
+def log_turn(turn_logwriter, turn_info):
+    """Log the information from this turn."""
+    pass

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -358,14 +358,14 @@ class PokemonEngine():
     def log_turn(self, turn_logwriter, turn_info):
         """Log the information from this turn."""
         for turn in turn_info:
-            new_row = []
-            new_row.append(self.game_state["num_turns"])
-            new_row.append(turn["attacker"])
-            new_row.append(self.game_state[turn["attacker"]]["active"])
-            new_row.append(self.game_state[turn["defender"]]["active"])
-            new_row.append(turn["move"]["name"])
-            new_row.append(turn["damage"])
-            turn_logwriter.write_line(new_row)
+            new_line = {}
+            new_line["turn_num"] = self.game_state["num_turns"]
+            new_line["player_id"] = turn["attacker"]
+            new_line["active"] = self.game_state[turn["attacker"]]["active"].name
+            new_line["target"] = self.game_state[turn["defender"]]["active"].name
+            new_line["move"] = turn["move"]["id"]
+            new_line["damage"] = turn["damage"]
+            turn_logwriter.write_line(new_line)
 
 
 def anonymize_gamestate_helper(data):


### PR DESCRIPTION
Addresses #38 
`PokemonEngine` now logs each battle that goes through it in its own CSV file.

The columns stored are:
- Turn Number
- Player attacking (player1/2, inferable from the file name)
- Active Pokemon
- Target/Opposing Pokemon
- Move chosen
- Damage Done

This does NOT account for switches, which really should be added to the turn_info variable at some point.