### PR TITLE
Add switching turn info

### DIFF
--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -117,7 +117,7 @@ class PokemonAgent(BaseAgent):
         """Calculate the opponent's battle position."""
         return calc_opp_position_helper(self.opp_gamestate)
 
-    def new_info(self, turn_info, my_id):
+    def new_info(self, raw_turn_info, my_id):
         """
         Get new info for opponent's game_state.
 
@@ -131,6 +131,8 @@ class PokemonAgent(BaseAgent):
             values of this dict. To know which values the method
             should be looking at in turn_info.
         """
+        turn_info = [turn for turn in raw_turn_info if turn["type"] == "ATTACK"]
+
         for info in turn_info:
             if info["attacker"] == my_id:
                 # We attacked, infer data about defending pokemon

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -194,6 +194,7 @@ class PokemonEngine():
         # New Data
         results = {}
         results["type"] = "SWITCH"
+        results["player"] = player
         results["old_active"] = cur_active.name
         results["new_active"] = new_active.name
         return [results]

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -190,6 +190,12 @@ class PokemonEngine():
         self.game_state[player]["team"].append(cur_active)
         new_active = self.game_state[player]["team"].pop(position)
         self.game_state[player]["active"] = new_active
+        
+        # New Data
+        results = {}
+        results["type"] = "SWITCH"
+        results["old_active"] = cur_active.name
+        results["new_active"] = new_active.name
 
     def attack(self, attacker, move):
         """

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -150,20 +150,20 @@ class PokemonEngine():
         if not p1_switch and not p2_switch:
             turn_info = self.turn_both_attack(move1, move2)
         elif p1_switch:
-            self.switch_pokemon("player1", move1[1])
+            turn_info.extend(self.switch_pokemon("player1", move1[1]))
             attack = self.game_state["player2"]["active"].moves[move2[1]]
             result = self.attack("player2", attack)
             if result is not None:
-                turn_info = result
+                turn_info.extend(result)
         elif p2_switch:
-            self.switch_pokemon("player2", move2[1])
+            turn_info.extend(self.switch_pokemon("player2", move2[1]))
             attack = self.game_state["player1"]["active"].moves[move1[1]]
             result = self.attack("player1", attack)
             if result is not None:
-                turn_info = result
+                turn_info.extend(result)
         else:
-            self.switch_pokemon("player1", move1[1])
-            self.switch_pokemon("player2", move2[1])
+            turn_info.extend(self.switch_pokemon("player1", move1[1]))
+            turn_info.extend(self.switch_pokemon("player2", move2[1]))
 
         return turn_info
 
@@ -196,6 +196,7 @@ class PokemonEngine():
         results["type"] = "SWITCH"
         results["old_active"] = cur_active.name
         results["new_active"] = new_active.name
+        return [results]
 
     def attack(self, attacker, move):
         """

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -190,7 +190,7 @@ class PokemonEngine():
         self.game_state[player]["team"].append(cur_active)
         new_active = self.game_state[player]["team"].pop(position)
         self.game_state[player]["active"] = new_active
-        
+
         # New Data
         results = {}
         results["type"] = "SWITCH"

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -417,6 +417,9 @@ class PokemonEngine():
     def log_turn(self, turn_logwriter, turn_info):
         """Log the information from this turn."""
         for turn in turn_info:
+            if turn["type"] == "SWITCH":
+                continue
+
             new_line = {}
             new_line["turn_num"] = self.game_state["num_turns"]
             new_line["player_id"] = turn["attacker"]

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -269,6 +269,7 @@ class PokemonEngine():
                     def_poke.boosts[stat] = min(def_poke.boosts[stat], 6)
 
         results = {}
+        results["type"] = "ATTACK"
         results["move"] = move
         results["damage"] = damage
         results["pct_damage"] = 100*damage/def_poke.max_hp

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -14,10 +14,11 @@ from pokemon_helpers.pokemon import default_boosts
 class PokemonEngine():
     """Class to run a pokemon game."""
 
-    def __init__(self, generation="gen7", turn_limit=2000):
+    def __init__(self, generation="gen7", turn_limit=2000, log_turns=False):
         """Initialize a new PokemonEngine."""
         self.generation = generation
         self.turn_limit = turn_limit
+        self.log_turn_flag = log_turns
         self.reset_game_state()
 
     def reset_game_state(self):
@@ -69,7 +70,9 @@ class PokemonEngine():
         self.initialize_battle(player1, player2)
 
         # Initialize Log Writer to write turn info
-        turn_logwriter = init_player_logwriter(player1, player2)
+        turn_logwriter = None
+        if self.log_turn_flag:
+            turn_logwriter = init_player_logwriter(player1, player2)
 
         # Initial setting of outcome variable
         outcome = self.win_condition_met()
@@ -417,6 +420,9 @@ class PokemonEngine():
 
     def log_turn(self, turn_logwriter, turn_info):
         """Log the information from this turn."""
+        if not self.log_turn_flag:
+            return
+
         for turn in turn_info:
             if turn["type"] == "SWITCH":
                 continue

--- a/interface/static/func.js
+++ b/interface/static/func.js
@@ -249,12 +249,12 @@ function update_log(data) {
     var outcome = data["outcome"]
     var turn_info = data["turn_info"]
 
-    // Switching
     var new_str = "";
 
-    // Attacking/Switching
+    // Log the info
     turn_info.forEach(function (datum) {
         if (datum["type"] === "SWITCH"){
+            // Switching
             if(datum["player"] === "player1") {
                 new_str = new_str.concat("Player switched to ");
             } else {
@@ -262,6 +262,7 @@ function update_log(data) {
             }
             new_str = new_str.concat(datum["new_active"], ".<br/>");
         } else {
+            // Attacking
             var player_attacking = datum["attacker"] === "player1"
             if (player_attacking) {
                 new_str = new_str.concat("Player's ")
@@ -282,9 +283,9 @@ function update_log(data) {
 
     if (outcome["finished"] === true) {
         if (outcome["winner"] === 1) {
-            new_entry.innerHTML += "PLAYER WINS!!"
+            new_entry.innerHTML += "You win! :D"
         } else {
-            new_entry.innerHTML += "OPPONENT WINS!"
+            new_entry.innerHTML += "Opponent wins... :("
         }
     }
     game_log.appendChild(new_entry)

--- a/interface/static/func.js
+++ b/interface/static/func.js
@@ -269,6 +269,10 @@ function update_log(data) {
     }
     // Attacking
     turn_info.forEach(function (datum) {
+        if (datum["type"] === "SWITCH"){
+            continue;
+        }
+
         var player_attacking = datum["attacker"] === "player1"
         if (player_attacking) {
             new_str = new_str.concat("Player's ")

--- a/interface/static/func.js
+++ b/interface/static/func.js
@@ -251,26 +251,11 @@ function update_log(data) {
 
     // Switching
     var new_str = "";
-    if (turn_info.length === 0 && !outcome["finished"]) {
-        new_str = new_str.concat("Player switched to ", data["player_active"]["name"], ".<br/>")
-        new_str = new_str.concat("Opponent switched to ", data["opp_active"]["name"], ".<br/>")
-    } else if (turn_info.length === 1 && !outcome["finished"]) {
-        if (turn_info[0]["attacker"] === "player1") {
-            //We attacked, opponent either switched or fainted
-            if (turn_info[0]["def_poke"] == data["opp_active"]["name"]) { // Didn't faint
-                new_str = new_str.concat("Opponent switched to ", data["opp_active"]["name"], ".<br/>")
-            }
-        } else {
-            // Opponent attacked, we switched.
-            if (turn_info[0]["def_poke"] == data["player_active"]["name"]) { // Didn't faint
-                new_str = new_str.concat("Player switched to ", data["player_active"]["name"], ".<br/>")
-            }
-        }
-    }
-    // Attacking
+
+    // Attacking/Switching
     turn_info.forEach(function (datum) {
         if (datum["type"] === "SWITCH"){
-            continue;
+            print(datum);
         } else {
             var player_attacking = datum["attacker"] === "player1"
             if (player_attacking) {

--- a/interface/static/func.js
+++ b/interface/static/func.js
@@ -271,22 +271,22 @@ function update_log(data) {
     turn_info.forEach(function (datum) {
         if (datum["type"] === "SWITCH"){
             continue;
-        }
-
-        var player_attacking = datum["attacker"] === "player1"
-        if (player_attacking) {
-            new_str = new_str.concat("Player's ")
         } else {
-            new_str = new_str.concat("Opponent's ")
+            var player_attacking = datum["attacker"] === "player1"
+            if (player_attacking) {
+                new_str = new_str.concat("Player's ")
+            } else {
+                new_str = new_str.concat("Opponent's ")
+            }
+    
+            new_str = new_str.concat(datum["atk_poke"], " attacked ", datum["def_poke"], " with ", datum["move"]["name"])
+            new_str = new_str.concat(". It did ", datum["pct_damage"], "%")
+    
+            if (!player_attacking) {
+                new_str = new_str.concat(" (", datum["damage"], ")")
+            }
+            new_str = new_str.concat(" damage.<br/>")
         }
-
-        new_str = new_str.concat(datum["atk_poke"], " attacked ", datum["def_poke"], " with ", datum["move"]["name"])
-        new_str = new_str.concat(". It did ", datum["pct_damage"], "%")
-
-        if (!player_attacking) {
-            new_str = new_str.concat(" (", datum["damage"], ")")
-        }
-        new_str = new_str.concat(" damage.<br/>")
     });
     new_entry.innerHTML += "".concat(new_str, "<br/>")
 

--- a/interface/static/func.js
+++ b/interface/static/func.js
@@ -255,7 +255,12 @@ function update_log(data) {
     // Attacking/Switching
     turn_info.forEach(function (datum) {
         if (datum["type"] === "SWITCH"){
-            print(datum);
+            if(datum["player"] === "player1") {
+                new_str = new_str.concat("Player switched to ");
+            } else {
+                new_str = new_str.concat("Opponent switched to ");
+            }
+            new_str = new_str.concat(datum["new_active"], ".<br/>");
         } else {
             var player_attacking = datum["attacker"] === "player1"
             if (player_attacking) {

--- a/tests/agent_tests/pokemon_agent_test.py
+++ b/tests/agent_tests/pokemon_agent_test.py
@@ -54,6 +54,7 @@ def test_opp_gamestate():
     assert pa1.opp_gamestate["data"]["active"]["name"] == "spinda"
 
     turn_info = {}
+    turn_info["type"] = "ATTACK"
     turn_info["attacker"] = "player2"
     turn_info["move"] = spinda.moves[0]
     turn_info["pct_damage"] = 28
@@ -193,6 +194,7 @@ def test_infer_investment():
 
     # Set the new info
     new_info = {}
+    new_info["type"] = "ATTACK"
     new_info["move"] = MOVE_DATA["tackle"]
     new_info["attacker"] = "player1"
     new_info["defender"] = "player2"
@@ -274,7 +276,7 @@ def test_infer_speed_investment():
                          anonymize_gamestate_helper(gamestate))
 
     new_info = {}
-    new_info = {}
+    new_info["type"] = "ATTACK"
     new_info["move"] = MOVE_DATA["tackle"]
     new_info["attacker"] = "player2"
     new_info["defender"] = "player1"


### PR DESCRIPTION
Addresses #65 

Switching info included in the turn_info returned from the `PokemonEngine`

Changes accounted for in the `PokemonAgent`, as well as in the Interface.

Last, `PokemonEngine` defaults to **NOT** logging the individual battles.