### PR TITLE
Add crits turn info

### DIFF
--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -156,7 +156,7 @@ class PokemonAgent(BaseAgent):
                 if info["move"] not in self.opp_gamestate["moves"][opp_name]:
                     self.opp_gamestate["moves"][opp_name].append(info["move"])
 
-        if len(turn_info) == 2:
+        if len(turn_info) == 2 and contains_switch(turn_info):
             self.update_speed_inference(turn_info, my_id)
 
     def update_speed_inference(self, turn_info, my_id):
@@ -425,3 +425,12 @@ def calc_opp_position_helper(opp_gs):
             opp_posn += poke["pct_hp"]
 
     return opp_posn
+
+
+def contains_switch(turn_info):
+    """Determine if switching info contains Switch information."""
+    for info in turn_info:
+        if info["type"] == "SWITCH":
+            return True
+
+    return False

--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -134,6 +134,11 @@ class PokemonAgent(BaseAgent):
         turn_info = [turn for turn in raw_turn_info if turn["type"] == "ATTACK"]
 
         for info in turn_info:
+            if info["critical_hit"]:
+                # Modify damage for critical hits
+                info["damage"] = info["damage"]*2/3
+                info["pct_damage"] = info["pct_damage"]*2/3
+
             if info["attacker"] == my_id:
                 # We attacked, infer data about defending pokemon
                 results, combinations = self.results_attacking(info)

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -497,9 +497,11 @@ def calculate_damage(move, attacker, defender):
     :param defender: dict or Pokemon
         Data of the defending Pokemon. Must support the [] operator.
     """
+    damage = 0
+    critical_hit = False
     # Status moves do no damage
     if move["category"] == "Status":
-        return 0
+        return damage, critical_hit
 
     # Calculate actual damage
     damage = floor(2*attacker["level"]/5 + 2)
@@ -516,7 +518,6 @@ def calculate_damage(move, attacker, defender):
     modifier = calculate_modifier(move, attacker, defender)
 
     # Critical Hit
-    critical_hit = False
     if uniform() < 0.0625:
         critical_hit = True
         modifier = modifier * 1.5
@@ -525,7 +526,7 @@ def calculate_damage(move, attacker, defender):
     modifier = modifier * uniform(0.85, 1.00)
     damage = floor(damage*modifier)
 
-    return damage, critical_hit
+    return (damage, critical_hit)
 
 
 def calculate_modifier(move, attacker, defender):

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -245,7 +245,7 @@ class PokemonEngine():
                 return None
 
         # Do Damage
-        damage = calculate_damage(move, atk_poke, def_poke)
+        damage, critical_hit = calculate_damage(move, atk_poke, def_poke)
         def_poke.current_hp -= damage
 
         # Thaw opponent if applicable
@@ -276,6 +276,7 @@ class PokemonEngine():
         results = {}
         results["type"] = "ATTACK"
         results["move"] = move
+        results["critical_hit"] = critical_hit
         results["damage"] = damage
         results["pct_damage"] = 100*damage/def_poke.max_hp
         results["attacker"] = attacker
@@ -515,14 +516,16 @@ def calculate_damage(move, attacker, defender):
     modifier = calculate_modifier(move, attacker, defender)
 
     # Critical Hit
+    critical_hit = False
     if uniform() < 0.0625:
+        critical_hit = True
         modifier = modifier * 1.5
 
     # Random Damage range
     modifier = modifier * uniform(0.85, 1.00)
     damage = floor(damage*modifier)
 
-    return damage
+    return damage, critical_hit
 
 
 def calculate_modifier(move, attacker, defender):


### PR DESCRIPTION
Addresses #69 

Add critical hit logging to the turn_info.

Also fix an oversight where calculating speed inference did not account for added switching information.