### PR TITLE
Refactor player id turn info

### DIFF
--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -129,7 +129,7 @@ class PokemonAgent(BaseAgent):
         """
         return calc_opp_position_helper(self.game_state.opp_gamestate)
 
-    def new_info(self, raw_turn_info, my_id):
+    def new_info(self, raw_turn_info):
         """
         Get new info for opponent's game_state.
 
@@ -141,7 +141,7 @@ class PokemonAgent(BaseAgent):
                 values of this dict. To know which values the method
                 should be looking at in turn_info.
         """
-        self.game_state.new_info(raw_turn_info, my_id)
+        self.game_state.new_info(raw_turn_info, self.id)
 
 
 def battle_position_helper(player_gs, opp_gs):

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -146,10 +146,6 @@ class PokemonEngine():
                 info["attacker"] = player_id_dict[info.get("attacker")]
                 info["defender"] = player_id_dict[info.get("defender")]
 
-            print("\nplayer:", info.get("player"))
-            print("attacker:", info.get("attacker"))
-            print("defender:", info.get("defender"))
-
         apply_status_damage(self.game_state["player1"]["active"])
         apply_status_damage(self.game_state["player2"]["active"])
 

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -133,6 +133,23 @@ class PokemonEngine():
         """
         turn_info = self.calculate_turn(player1_move, player2_move)
 
+        # Go from player1/2 to the players' IDs
+        player_id_dict = {
+            "player1": player1.id,
+            "player2": player2.id,
+            None: None
+        }
+        for info in turn_info:
+            if "player" in info:
+                info["player"] = player_id_dict[info.get("player")]
+            elif "attacker" in info:
+                info["attacker"] = player_id_dict[info.get("attacker")]
+                info["defender"] = player_id_dict[info.get("defender")]
+
+            print("\nplayer:", info.get("player"))
+            print("attacker:", info.get("attacker"))
+            print("defender:", info.get("defender"))
+
         apply_status_damage(self.game_state["player1"]["active"])
         apply_status_damage(self.game_state["player2"]["active"])
 

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -153,8 +153,8 @@ class PokemonEngine():
         apply_status_damage(self.game_state["player1"]["active"])
         apply_status_damage(self.game_state["player2"]["active"])
 
-        player1.new_info(turn_info, "player1")
-        player2.new_info(turn_info, "player2")
+        player1.new_info(turn_info)
+        player2.new_info(turn_info)
 
         # Figure out who faints at the end of this turn.
         if self.game_state["player1"]["active"].current_hp <= 0:


### PR DESCRIPTION
Instead of passing in `player1/2` and having to keep track of who is player1 and player2, the agents are just going to tell whose moves are what based on their IDs.