### PR TITLE
Enhancement adjustable param rps

### DIFF
--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -17,8 +17,10 @@ class AdjustingRPSAgent(RPSAgent):
         super().__init__(id_in=id_in, strategy_in=strategy_in)
         self.type = "PopnAdjust"
         self.original_strategy = deepcopy(self.strategy)
-        self.counts = [val * weight for val in self.strategy]
+        self.counts = [int(val * weight) for val in self.strategy]
+        self.weight = weight
 
     def reset_state(self):
         """Reset state once game is finished."""
         self.strategy = deepcopy(self.original_strategy)
+        self.counts = [int(val * self.weight) for val in self.strategy]

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -23,7 +23,7 @@ class AdjustingRPSAgent(RPSAgent):
     def reset_state(self):
         """Reset state once game is finished."""
         self.strategy = deepcopy(self.original_strategy)
-        self.counts = [int(val * self.weight) for val in self.strategy]
+        self.counts = [val * self.weight for val in self.strategy]
 
     def update_info(self, *args, **kwargs):
         """Update the agent's counts and strategy."""

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -17,7 +17,7 @@ class AdjustingRPSAgent(RPSAgent):
         super().__init__(id_in=id_in, strategy_in=strategy_in)
         self.type = "PopnAdjust"
         self.original_strategy = deepcopy(self.strategy)
-        self.counts = [int(val * weight) for val in self.strategy]
+        self.counts = [val * weight for val in self.strategy]
         self.weight = weight
 
     def reset_state(self):

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -24,3 +24,9 @@ class AdjustingRPSAgent(RPSAgent):
         """Reset state once game is finished."""
         self.strategy = deepcopy(self.original_strategy)
         self.counts = [int(val * self.weight) for val in self.strategy]
+
+    def update_info(self, *args, **kwargs):
+        """Update the agent's counts and strategy."""
+        opp_move = kwargs.get("opp_move")
+        self.counts[opp_move] += 1
+        self.strategy = [val/sum(self.counts) for val in self.counts]

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -28,5 +28,5 @@ class AdjustingRPSAgent(RPSAgent):
     def update_info(self, *args, **kwargs):
         """Update the agent's counts and strategy."""
         opp_move = kwargs.get("opp_move")
-        self.counts[opp_move] += 1
+        self.counts[(opp_move + 1) % 3] += 1
         self.strategy = [val/sum(self.counts) for val in self.counts]

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -1,0 +1,24 @@
+"""RPS Agent who updates based on all games played."""
+
+from copy import deepcopy
+
+from agent.rps_agent import RPSAgent
+
+
+class AdjustingRPSAgent(RPSAgent):
+    """
+    Class for the AdjustingRPSAgent
+
+    Updates strategy based on all games played.
+    """
+
+    def __init__(self, id_in=None, strategy_in="uniform", weight=3):
+        """Initialize this Agent."""
+        super().__init__(id_in=id_in, strategy_in=strategy_in)
+        self.type = "PopnAdjust"
+        self.original_strategy = deepcopy(self.strategy)
+        self.counts = [val * weight for val in self.strategy]
+
+    def reset_state(self):
+        """Reset state once game is finished."""
+        self.strategy = deepcopy(self.original_strategy)

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -9,7 +9,7 @@ class AdjustingRPSAgent(RPSAgent):
     """
     Class for the AdjustingRPSAgent
 
-    Updates strategy based on all games played.
+    Updates strategy based on all sets played against single opponent.
     """
 
     def __init__(self, id_in=None, strategy_in="uniform", weight=1):

--- a/agent/adjusting_rps_agent.py
+++ b/agent/adjusting_rps_agent.py
@@ -12,7 +12,7 @@ class AdjustingRPSAgent(RPSAgent):
     Updates strategy based on all games played.
     """
 
-    def __init__(self, id_in=None, strategy_in="uniform", weight=3):
+    def __init__(self, id_in=None, strategy_in="uniform", weight=1):
         """Initialize this Agent."""
         super().__init__(id_in=id_in, strategy_in=strategy_in)
         self.type = "PopnAdjust"

--- a/agent/counter_rps_agent.py
+++ b/agent/counter_rps_agent.py
@@ -17,10 +17,16 @@ class CounterRPSAgent(RPSAgent):
         super().__init__(id_in=id_in)
         self.reset_state()
         self.type = "counter"
+        self.last_move = None
 
     def reset_state(self):
         """Reset state once game is finished."""
         self.last_move = None
+
+    def update_info(self, *args, **kwargs):
+        """Store opponent's last move."""
+        last_move = kwargs.get("last_move")
+        self.last_move = last_move
 
     def make_move(self):
         """

--- a/agent/rps_agent.py
+++ b/agent/rps_agent.py
@@ -68,6 +68,14 @@ class RPSAgent(BaseAgent):
 
         raise RuntimeError("Something went wrong with strategy selection")
 
+    def update_info(self, *args, **kwargs):
+        """
+        Update player with new information.
+
+        To be defined by subclass.
+        """
+        pass
+
     def print_info(self):
         """Print the info on this player."""
         print("Player: {}".format(self.id))

--- a/battle_engine/rockpaperscissors.py
+++ b/battle_engine/rockpaperscissors.py
@@ -47,6 +47,8 @@ class RPSEngine:
         for player in [player1, player2]:
             if isinstance(player, CounterRPSAgent):
                 player.reset_state()
+            elif isinstance(player, AdjustingRPSAgent):
+                player.reset_state()
 
         outcome = None
         for _ in range(self.num_games):

--- a/battle_engine/rockpaperscissors.py
+++ b/battle_engine/rockpaperscissors.py
@@ -2,7 +2,7 @@
 from random import random
 
 from agent.counter_rps_agent import CounterRPSAgent
-
+from agent.adjusting_rps_agent import AdjustingRPSAgent
 
 class RPSEngine:
     """Engine to run a game of rock, paper, scissors."""
@@ -44,10 +44,9 @@ class RPSEngine:
         """
         self.reset_game_state()
 
-        if isinstance(player1, CounterRPSAgent):
-            player1.reset_state()
-        if isinstance(player2, CounterRPSAgent):
-            player2.reset_state()
+        for player in [player1, player2]:
+            if isinstance(player, CounterRPSAgent):
+                player.reset_state()
 
         outcome = None
         for _ in range(self.num_games):
@@ -55,9 +54,14 @@ class RPSEngine:
             p2_move = player2.make_move()
 
             if isinstance(player1, CounterRPSAgent):
-                player1.last_move = p2_move
+                player1.update_info(last_move=p2_move)
+            elif isinstance(player1, AdjustingRPSAgent):
+                player1.update_info(opp_move=p2_move)
+
             if isinstance(player2, CounterRPSAgent):
-                player2.last_move = p1_move
+                player2.update_info(last_move=p1_move)
+            elif isinstance(player2, AdjustingRPSAgent):
+                player2.update_info(opp_move=p1_move)
 
             results = rps_logic(p1_move, p2_move)
             self.game_state[results] += 1

--- a/sample_simulations/sample_multiturn_rps.yaml
+++ b/sample_simulations/sample_multiturn_rps.yaml
@@ -1,11 +1,12 @@
-# Best of 5 RPS Tournament
-# 30% Rock, 30% Paper, 30% Scissors, 5% Uniform, 5% Counter
-# 50000 games, 40 players
+# Best of 9 RPS Tournament
+# 25% Rock, 25% Paper, 25% Scissors,
+# 10% Uniform, 7.5% Counter, 7.5% Adjusting
+# 50000 games, 100 players
 # Random Ladder
 
 game_choice: 3
-num_rounds: 5
+num_rounds: 9
 ladder: 1
 num_games: 50000
-num_players: 40
+num_players: 100
 config: "sample_simulations/sim_configs/sample_rps_config.json"

--- a/sample_simulations/sim_configs/sample_rps_config.json
+++ b/sample_simulations/sim_configs/sample_rps_config.json
@@ -1,27 +1,33 @@
 [
     {
-        "proportion": 0.3,
+        "proportion": 0.25,
         "agent_type": "Rock",
         "agent_strategy": [1, 0, 0]
     },
     {
-        "proportion": 0.3,
+        "proportion": 0.25,
         "agent_type": "Paper",
         "agent_strategy": [0, 1, 0]
     },
     {
-        "proportion": 0.3,
+        "proportion": 0.25,
         "agent_type": "Scissors",
         "agent_strategy": [0, 0, 1]
     },
     {
-        "proportion": 0.05,
+        "proportion": 0.1,
         "agent_type": "Uniform",
         "agent_strategy": [0.33, 0.33, 0.33]
     },
     {
-        "proportion": 0.05,
+        "proportion": 0.075,
         "agent_type": "Counter",
         "agent_strategy": null
+    },
+    {
+        "proportion": 0.075,
+        "agent_type": "Adjusting",
+        "agent_strategy": "Uniform",
+        "weight": 5
     }
 ]

--- a/sample_simulations/sim_configs/sample_rps_config.json
+++ b/sample_simulations/sim_configs/sample_rps_config.json
@@ -29,7 +29,7 @@
         "proportion": 0.075,
         "agent_type": "Adjusting",
         "agent_class": "adjusting",
-        "agent_strategy": "Uniform",
+        "agent_strategy": "uniform",
         "weight": 5
     }
 ]

--- a/sample_simulations/sim_configs/sample_rps_config.json
+++ b/sample_simulations/sim_configs/sample_rps_config.json
@@ -28,7 +28,7 @@
     {
         "proportion": 0.075,
         "agent_type": "Adjusting",
-        "agent_class": "adjusting"
+        "agent_class": "adjusting",
         "agent_strategy": "Uniform",
         "weight": 5
     }

--- a/sample_simulations/sim_configs/sample_rps_config.json
+++ b/sample_simulations/sim_configs/sample_rps_config.json
@@ -22,11 +22,13 @@
     {
         "proportion": 0.075,
         "agent_type": "Counter",
+        "agent_class": "counter",
         "agent_strategy": null
     },
     {
         "proportion": 0.075,
         "agent_type": "Adjusting",
+        "agent_class": "adjusting"
         "agent_strategy": "Uniform",
         "weight": 5
     }

--- a/simulation/rps_simulation.py
+++ b/simulation/rps_simulation.py
@@ -7,6 +7,7 @@ from simulation.base_type_logging_simulation import BaseLoggingSimulation
 from battle_engine.rockpaperscissors import RPSEngine
 from agent.rps_agent import RPSAgent
 from agent.counter_rps_agent import CounterRPSAgent
+from agent.adjusting_rps_agent import AdjustingRPSAgent
 from file_manager.log_writer import LogWriter
 
 
@@ -41,10 +42,14 @@ class RPSSimulation(BaseLoggingSimulation):
             for agent_ind in range(num_agents):
                 player = None
                 agent_id = "{}_{}".format(conf["agent_type"], agent_ind)
-                if conf["agent_strategy"] is not None:
-                    player = RPSAgent(id_in=agent_id, strategy_in=conf["agent_strategy"])
-                else:
+                strategy = conf.get("agent_strategy", None)
+                weight = conf.get("weight", 1)
+                if conf.get("agent_class") == "counter":
                     player = CounterRPSAgent(id_in=agent_id)
+                elif conf.get("agent_class") == "adjusting":
+                    player = AdjustingRPSAgent(id_in=agent_id, strategy_in=strategy, weight=weight)
+                else:
+                    player = RPSAgent(id_in=agent_id, strategy_in=strategy)
 
                 player.type = conf["agent_type"]
                 self.ladder.add_player(player)

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -1,11 +1,14 @@
 """Test for AdjustingRPSAgent."""
 
-from agent.adjusting_rps_agent import RPSAgent
+from agent.adjusting_rps_agent import AdjustingRPSAgent
 
 
 def test_init():
     """Test Initialization method."""
-    pass
+    arps = AdjustingRPSAgent()
+    assert arps.weight == 3
+    assert arps.original_strategy == arps.strategy
+    assert arps.counts == [1, 1, 1]
 
 
 test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -5,10 +5,16 @@ from agent.adjusting_rps_agent import AdjustingRPSAgent
 
 def test_init():
     """Test Initialization method."""
+    # Test that initializes default
     arps = AdjustingRPSAgent()
-    assert arps.weight == 3
+    assert arps.weight == 1
     assert arps.original_strategy == arps.strategy
-    assert arps.counts == [1, 1, 1]
+    assert arps.counts == [1/3, 1/3, 1/3]
+
+    # Tests when weights are not defaults
+    arps_weight = AdjustingRPSAgent(weight=6)
+    assert arps_weight.weight == 6
+    assert arps_weight.counts == [2, 2, 2]
 
 
 test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -30,5 +30,15 @@ def test_init():
     arps_nstd_weight = AdjustingRPSAgent(strategy_in="rock", weight=5)
     assert arps_nstd_weight.counts == [5, 0 ,0]
 
+def test_update_info_and_reset():
+    """Test that update_info works properly, as does resetting."""
+    arps = AdjustingRPSAgent()
+    assert arps.strategy == [1/3, 1/3, 1/3]
+
+    arps.update_info(opp_move=0)
+    assert arps.counts == [1/3, 4/3, 1/3]
+    assert arps.strategy == [1/4, 1/2, 1/4]
+
 
 test_init()
+test_update_info_and_reset()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -38,6 +38,7 @@ def test_update_info_and_reset():
 
     arps.update_info(opp_move=0)
     assert arps.counts == [1/3, 4/3, 1/3]
+    assert arps.original_strategy == [1/3, 1/3, 1/3]
     assert [round(prob, 4) for prob in arps.strategy] == [0.1667, 0.6667, 0.1667]
 
     arps.reset_state()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -11,10 +11,20 @@ def test_init():
     assert arps.original_strategy == arps.strategy
     assert arps.counts == [1/3, 1/3, 1/3]
 
+    test_init_weights()
+
+
+def test_init_weights():
+    """Tests weights formatting of initialization."""
     # Tests when weights are not defaults
-    arps_weight = AdjustingRPSAgent(weight=6)
-    assert arps_weight.weight == 6
-    assert arps_weight.counts == [2, 2, 2]
+    arps_int = AdjustingRPSAgent(weight=6)
+    assert arps_int.weight == 6
+    assert arps_int.counts == [2, 2, 2]
+
+    # Test non-integer weights
+    arps_float = AdjustingRPSAgent(weight=2)
+    assert arps_float.weight == 2
+    assert arps_float.counts == [2/3, 2/3, 2/3]
 
 
 test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -37,7 +37,11 @@ def test_update_info_and_reset():
 
     arps.update_info(opp_move=0)
     assert arps.counts == [1/3, 4/3, 1/3]
-    assert arps.strategy == [1/4, 1/2, 1/4]
+    assert [round(prob, 4) for prob in arps.strategy] == [0.1667, 0.6667, 0.1667]
+
+    arps.reset_state()
+    assert arps.strategy == [1/3, 1/3, 1/3]
+    assert arps.counts == [1/3, 1/3, 1/3]
 
 
 test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -32,6 +32,7 @@ def test_init():
 
 def test_update_info_and_reset():
     """Test that update_info works properly, as does resetting."""
+    # Test updating with default parameters
     arps = AdjustingRPSAgent()
     assert arps.strategy == [1/3, 1/3, 1/3]
 
@@ -42,6 +43,13 @@ def test_update_info_and_reset():
     arps.reset_state()
     assert arps.strategy == [1/3, 1/3, 1/3]
     assert arps.counts == [1/3, 1/3, 1/3]
+
+    # Make sure that weights are accounted for
+    arps_weight = AdjustingRPSAgent(weight=3)
+
+    arps_weight.update_info(opp_move=1)
+    assert arps_weight.counts == [3, 3, 4]
+    assert arps_weight.strategy == [0.3, 0.3, 0.4]
 
 
 test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -11,11 +11,6 @@ def test_init():
     assert arps.original_strategy == arps.strategy
     assert arps.counts == [1/3, 1/3, 1/3]
 
-    test_init_weights()
-
-
-def test_init_weights():
-    """Tests weights formatting of initialization."""
     # Tests when weights are not defaults
     arps_int = AdjustingRPSAgent(weight=6)
     assert arps_int.weight == 6
@@ -25,6 +20,15 @@ def test_init_weights():
     arps_float = AdjustingRPSAgent(weight=2)
     assert arps_float.weight == 2
     assert arps_float.counts == [2/3, 2/3, 2/3]
+
+    # Test that non-standard strategy set properly
+    arps_nstd = AdjustingRPSAgent(strategy_in="rock")
+    assert arps_nstd.weight == 1
+    assert arps_nstd.counts == [1, 0, 0]
+
+    # Test that strategy plays nicely with weight
+    arps_nstd_weight = AdjustingRPSAgent(strategy_in="rock", weight=5)
+    assert arps_nstd_weight.counts == [5, 0 ,0]
 
 
 test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -1,0 +1,11 @@
+"""Test for AdjustingRPSAgent."""
+
+from agent.adjusting_rps_agent import RPSAgent
+
+
+def test_init():
+    """Test Initialization method."""
+    pass
+
+
+test_init()

--- a/tests/agent_tests/adjusting_rps_agent_test.py
+++ b/tests/agent_tests/adjusting_rps_agent_test.py
@@ -45,12 +45,15 @@ def test_update_info_and_reset():
     assert arps.counts == [1/3, 1/3, 1/3]
 
     # Make sure that weights are accounted for
-    arps_weight = AdjustingRPSAgent(weight=3)
+    arps_weight = AdjustingRPSAgent(weight=9)
 
     arps_weight.update_info(opp_move=1)
     assert arps_weight.counts == [3, 3, 4]
     assert arps_weight.strategy == [0.3, 0.3, 0.4]
 
+    arps_weight.reset_state()
+    assert arps_weight.strategy == [1/3, 1/3, 1/3]
+    assert arps_weight.counts == [3, 3, 3]
 
 test_init()
 test_update_info_and_reset()

--- a/tests/agent_tests/counter_rps_agent_test.py
+++ b/tests/agent_tests/counter_rps_agent_test.py
@@ -41,6 +41,16 @@ def test_reset_state():
     assert c_player.last_move is None
 
 
+def test_update_info():
+    """Assert that player actually updates its internal state."""
+    c_player = CounterRPSAgent()
+    assert c_player.last_move is None
+
+    c_player.update_info(last_move=1)
+    assert c_player.last_move == 1
+
+
 test_init()
 test_make_move()
 test_reset_state()
+test_update_info


### PR DESCRIPTION
Addresses Issue #109 

## Updates
Adds new agent for RPS Simulations, the `AdjustableRPSAgent`. This agent will update its strategy based on the opponent it plays, re-calculating its strategy vector based on a weighted initial strategy and the plays it has seen.

## Test Cases
`agent_tests/adjusting_rps_agent_test.py`
- Default initialization
  - Default weight is 1
  - Original Strategy and Actual Strategy are the same (uniform)
  - Counts are [1/3, 1/3, 1/3]
- Default initialization, weighting factor is 6
  - Weight is 6
  - Counts are [2, 2, 2]
- Initialize non-default strategy vector (rock), default weight
  - Counts are [1, 0, 0]
- Initialize non-default strategy vector (rock), weighting factor of 5
  - Counts are [5, 0, 0]
- Update Information with default weight
  - Counts are [1/3, 4/3, 1/3]
  - Strategy is [1/6, 2/3, 1/6]
- Resetting state after update with default weight
  - Strategy and Counts are [1/3, 1/3, 1/3]
- Update Information with non-default weight (9)
  - Counts are [3, 3, 4]
  - Strategy is [0.3, 0.3, 0.4]
- Resetting state after update with non-default weight (9)
  - Counts are [3, 3, 3]
  - Strategy is [1/3, 1/3, 1/3]