### PR TITLE
Enhancement add status to bppa

### DIFF
--- a/agent/basic_planning_pokemon_agent.py
+++ b/agent/basic_planning_pokemon_agent.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 
 from agent.basic_pokemon_agent import PokemonAgent
 from agent.basic_pokemon_agent import calc_opp_position_helper, calc_position_helper
+from calculate import calc_boost_factor
 from config import USAGE_STATS, POKEMON_DATA, MOVE_DATA
 from config import (PAR_STATUS)
 
@@ -320,8 +321,12 @@ class BasicPlanningPokemonAgent(PokemonAgent):
             if opp_gs["data"]["active"]["status"] == PAR_STATUS:
                 opp_modifier = opp_modifier * 0.5
 
+            # Factor in Boosts
+            player_modifier = player_modifier * calc_boost_factor(p_poke, "spe")
+            opp_modifier = opp_modifier * calc_boost_factor(opp_gs["data"]["active"], "spe")
+
             # Assume that any speed is possible, which isn't exactly correct
-            return p_poke.speed > (min_opp_spe + max_opp_spe) / 2
+            return player_modifier * p_poke.speed > opp_modifier * (min_opp_spe + max_opp_spe) / 2
 
         # Moves of different priority will always go in priority order
         return p_move["priority"] > o_move["priority"]

--- a/agent/basic_planning_pokemon_agent.py
+++ b/agent/basic_planning_pokemon_agent.py
@@ -6,8 +6,7 @@ from copy import deepcopy
 from agent.basic_pokemon_agent import PokemonAgent
 from agent.basic_pokemon_agent import calc_opp_position_helper, calc_position_helper
 from config import USAGE_STATS, POKEMON_DATA, MOVE_DATA
-from config import (PAR_STATUS, FRZ_STATUS, SLP_STATUS,
-                    BRN_STATUS, PSN_STATUS, TOX_STATUS)
+from config import (PAR_STATUS)
 
 
 class BasicPlanningPokemonAgent(PokemonAgent):

--- a/agent/basic_planning_pokemon_agent.py
+++ b/agent/basic_planning_pokemon_agent.py
@@ -218,6 +218,7 @@ class BasicPlanningPokemonAgent(PokemonAgent):
         o_move = MOVE_DATA[o_opt[1]]
         o_poke_name = opp_gs["data"]["active"]["name"]
         o_poke = POKEMON_DATA[o_poke_name]
+        o_poke["status"] = opp_gs["data"]["active"]["status"]
         params = self.game_state.opp_gamestate["investment"][o_poke_name]
 
         # We do not handle status moves at this point in time.

--- a/agent/basic_planning_pokemon_agent.py
+++ b/agent/basic_planning_pokemon_agent.py
@@ -5,9 +5,9 @@ from copy import deepcopy
 
 from agent.basic_pokemon_agent import PokemonAgent
 from agent.basic_pokemon_agent import calc_opp_position_helper, calc_position_helper
-from calculate import calc_boost_factor
 from config import USAGE_STATS, POKEMON_DATA, MOVE_DATA
 from config import (PAR_STATUS)
+from pokemon_helpers.calculate import calc_boost_factor
 
 
 class BasicPlanningPokemonAgent(PokemonAgent):

--- a/agent/basic_planning_pokemon_agent.py
+++ b/agent/basic_planning_pokemon_agent.py
@@ -314,19 +314,15 @@ class BasicPlanningPokemonAgent(PokemonAgent):
             min_opp_spe, max_opp_spe = speed_pairs
 
             # Factor in status
-            player_modifier = 1
             opp_modifier = 1
-            if p_poke.status == PAR_STATUS:
-                player_modifier = player_modifier * 0.5
             if opp_gs["data"]["active"]["status"] == PAR_STATUS:
                 opp_modifier = opp_modifier * 0.5
 
             # Factor in Boosts
-            player_modifier = player_modifier * calc_boost_factor(p_poke, "spe")
             opp_modifier = opp_modifier * calc_boost_factor(opp_gs["data"]["active"], "spe")
 
             # Assume that any speed is possible, which isn't exactly correct
-            return player_modifier * p_poke.speed > opp_modifier * (min_opp_spe + max_opp_spe) / 2
+            return p_poke.effective_stat("spe") > opp_modifier * (min_opp_spe + max_opp_spe) / 2
 
         # Moves of different priority will always go in priority order
         return p_move["priority"] > o_move["priority"]

--- a/pokemon_helpers/calculate.py
+++ b/pokemon_helpers/calculate.py
@@ -108,3 +108,19 @@ def generate_all_ev_combinations():
     combinations["hp"].append({"max_evs": False})
 
     return combinations
+
+
+def calc_boost_factor(pokemon, stat_name):
+    """
+    Calculate the multiplicative modifier for a pokemon's stat.
+
+    Args:
+        pokemon (Pokemon): The pokemon for whom we are calculating.
+        stat (str): The stat for which we are calculating this for.
+
+    Returns:
+        The multiplier to apply to that pokemon's stat.
+
+    """
+    return max(2, 2 + pokemon["boosts"][stat_name]) / \
+             max(2, 2 - pokemon["boosts"][stat_name])

--- a/pokemon_helpers/calculate.py
+++ b/pokemon_helpers/calculate.py
@@ -123,4 +123,4 @@ def calc_boost_factor(pokemon, stat_name):
 
     """
     return max(2, 2 + pokemon["boosts"][stat_name]) / \
-             max(2, 2 - pokemon["boosts"][stat_name])
+        max(2, 2 - pokemon["boosts"][stat_name])

--- a/pokemon_helpers/damage_stats.py
+++ b/pokemon_helpers/damage_stats.py
@@ -9,7 +9,7 @@ from math import ceil
 from math import floor
 
 from battle_engine.pokemon_engine import calculate_modifier
-
+from pokemon_helpers.calculate import calc_boost_factor
 
 class DamageStatCalc():
     """Class to estimate damage taken/given."""
@@ -203,10 +203,8 @@ def boost_modifier(move, attacker, defender):
     atk_boost = 1
     def_boost = 1
     if "boosts" in attacker:
-        atk_boost = max(2, 2 + attacker["boosts"][stats[0]]) / \
-            max(2, 2 - attacker["boosts"][stats[0]])
+        atk_boost = calc_boost_factor(attacker, stats[0])
     if "boosts" in defender:
-        def_boost = max(2, 2 + defender["boosts"][stats[1]]) / \
-            max(2, 2 - defender["boosts"][stats[1]])
+        def_boost = calc_boost_factor(defender, stats[1])
 
     return atk_boost/def_boost

--- a/pokemon_helpers/damage_stats.py
+++ b/pokemon_helpers/damage_stats.py
@@ -11,6 +11,8 @@ from math import floor
 from battle_engine.pokemon_engine import calculate_modifier
 from pokemon_helpers.calculate import calc_boost_factor
 
+from config import BRN_STATUS
+
 class DamageStatCalc():
     """Class to estimate damage taken/given."""
 
@@ -54,6 +56,11 @@ class DamageStatCalc():
 
         max_dmg = d_atk * modifier * move["basePower"]
         max_dmg = max_dmg / (d_hp * d_def)
+
+        # Burned attackers have their damage halved
+        atk_status = attacker.get("status")
+        if atk_status == BRN_STATUS and move_cat[0] == "atk":
+            max_dmg = 0.5 * max_dmg
 
         # Ceiling/Floor so we get a conservative estimate
         return (floor(0.85*max_dmg), ceil(max_dmg))

--- a/pokemon_helpers/damage_stats.py
+++ b/pokemon_helpers/damage_stats.py
@@ -58,8 +58,7 @@ class DamageStatCalc():
         max_dmg = max_dmg / (d_hp * d_def)
 
         # Burned attackers have their damage halved
-        atk_status = attacker.get("status")
-        if atk_status == BRN_STATUS and move_cat[0] == "atk":
+        if attacker.get("status") == BRN_STATUS and move_cat[0] == "atk":
             max_dmg = 0.5 * max_dmg
 
         # Ceiling/Floor so we get a conservative estimate

--- a/pokemon_helpers/damage_stats.py
+++ b/pokemon_helpers/damage_stats.py
@@ -10,8 +10,8 @@ from math import floor
 
 from battle_engine.pokemon_engine import calculate_modifier
 from pokemon_helpers.calculate import calc_boost_factor
-
 from config import BRN_STATUS
+
 
 class DamageStatCalc():
     """Class to estimate damage taken/given."""

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -162,7 +162,7 @@ class Pokemon:
 
     def get(self, key, default=None):
         """
-        Define .get() on this object.
+        Extend __getitem__ to have defaults.
 
         Args:
             key (str): Attribute of this object to get.

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -160,6 +160,25 @@ class Pokemon:
 
         return val
 
+    def get(self, key, default=None):
+        """
+        Define .get() on this object.
+
+        Args:
+            key (str): Attribute of this object to get.
+            default: What to return if there is no such key.
+
+        Returns:
+            Value of this object's key, if it exists. If not, return value
+                specified in default.
+
+        """
+        if self.__contains__(key):
+            return self.__getitem__(key)
+
+        return default
+
+
     def __getitem__(self, key):
         """
         Define [] operating on this object.

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -178,7 +178,6 @@ class Pokemon:
 
         return default
 
-
     def __getitem__(self, key):
         """
         Define [] operating on this object.

--- a/tests/agent_tests/basic_planning_pkmn_agent_test.py
+++ b/tests/agent_tests/basic_planning_pkmn_agent_test.py
@@ -51,7 +51,17 @@ def test_make_move():
 
 
 def test_determine_faster():
-    """Test ability to determine if player faster."""
+    """
+    Test ability to determine if player faster.
+
+    A -> Abomasnow, S -> Spinda
+    Under normal conditions, A is faster.
+    When A is paralyzed, S is faster.
+    When S is boosted, S is faster.
+    When A and S are both boosted, A is faster.
+    When A and S are both boosted, and A is paralyzed, S is faster.
+
+    """
     player_spinda = Pokemon(name="spinda", moves=["tackle"])
     opp_abomasnow = Pokemon(name="abomasnow", moves=["tackle"])
 

--- a/tests/misc_tests/damage_stats_test.py
+++ b/tests/misc_tests/damage_stats_test.py
@@ -5,6 +5,7 @@ from pokemon_helpers.damage_stats import DamageStatCalc
 
 from config import MOVE_DATA
 from config import POKEMON_DATA
+from config import BRN_STATUS
 
 
 def test_init():
@@ -44,6 +45,7 @@ def test_dmg_range():
     range_def_params()
     range_hp_params()
     range_boosts()
+    range_status()
 
 
 def range_no_params():
@@ -173,6 +175,25 @@ def range_boosts():
     dmg_range = dsc.calculate_range(move, attacker, defender, params)
     assert dmg_range[0] == 36
     assert dmg_range[1] == 44
+
+
+def range_status():
+    """Test damage range with burn status."""
+    dsc = DamageStatCalc()
+    params = {}
+    params["atk"] = {}
+    params["def"] = {}
+    params["hp"] = {}
+    move = MOVE_DATA["tackle"]
+
+    attacker = Pokemon(name="spinda", moves=["tackle"])
+    defender = Pokemon(name="spinda", moves=["tackle"])
+
+    attacker.status = BRN_STATUS
+
+    dmg_range = dsc.calculate_range(move, attacker, defender, params)
+    assert dmg_range[0] == 8
+    assert dmg_range[1] == 10
 
 
 test_init()

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -204,9 +204,18 @@ def test_attack_burn():
         exploud_brn.effective_stat("atk")
 
 
+def test_get_method():
+    """Test .get() on a Pokemon."""
+    pkmn = Pokemon(name="spinda", moves=["tackle"], level=50)
+
+    assert pkmn.get("name") == "spinda"
+    assert pkmn.get("DOOT") == None
+
+
 test_init()
 test_param_validation()
 test_stats_calculation()
 test_getitem_validation()
 test_effective_stats()
 test_status()
+test_get_method()


### PR DESCRIPTION
Addresses Issue #111

## Updates
`BasicPlanningPokemonAgent`'s move calculation has been expanded to account for paralysis speed drop, and burn's attack drop.

## Test Cases
`agent_tests/basic_planning_pkmn_agent_test.py`
- A -> Abomasnow, S -> Spinda
- Under normal conditions, A is faster.
- When A is paralyzed, S is faster.
- When S is boosted, S is faster.
- When A and S are both boosted, A is faster.
- When A and S are both boosted, and A is paralyzed, S is faster.

`misc_tests/pokemon_test.py`
- .get("name") returns pokemon name
- .get("doot") returns the default value (None)

`misc_tests/damage_stats_test.py`
- When burned, Spinda's damage estimate for tackle is halved