### PR TITLE
Bug pool size not large enough

### DIFF
--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -93,8 +93,17 @@ class BaseLadder:
         Returns:
             A pair of players matched by the ladder's match_func.
 
+        Raises:
+            RuntimeError: If either no players in the pool or
+                only a single player available.
+
         """
         self.thread_lock.acquire()
+
+        # Check if no players ready
+        if not self.player_pool or len(self.player_pool) == 1:
+            self.thread_lock.release()
+            raise RuntimeError("No players left in pool.")
 
         # Select a random player
         player_ind = randint(a=0, b=(len(self.player_pool)-1))

--- a/simulation/pkmn_simulation.py
+++ b/simulation/pkmn_simulation.py
@@ -121,7 +121,13 @@ def battle(main_sim, battle_queue, output_queue, type_queue, start_time):
     """
     while not battle_queue.empty():
         battle_queue.get()
-        results = main_sim.ladder.run_game()
+        results = None
+        while results is None:
+            try:
+                results = main_sim.ladder.run_game()
+            except RuntimeError as rte:
+                print(rte, main_sim.ladder.thread_lock.locked())
+
         output_queue.put(results)
         if battle_queue.qsize() % main_sim.data_delay == 0:
             type_queue.put(calculate_avg_elo(main_sim.ladder))

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -164,6 +164,17 @@ def test_match_error():
     except RuntimeError:
         pass
 
+    # Originally enough players, but not enough afterwards
+    for _ in range(2):
+        lad.add_player(BaseAgent())
+
+    try:
+        lad.match_players()  # 3 players in pool
+        lad.match_players()  # Only 1 player in pool
+        assert False
+    except RuntimeError:
+        pass
+
 
 test_match_basic()
 test_match_func()

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -144,8 +144,30 @@ def test_selection_size():
     assert len(lad.get_candidate_matches(base_player)) == 15
 
 
+def test_match_error():
+    """Ensure RuntimeError is thrown when no players available to match."""
+    lad = WeightedLadder()
+    ba1 = BaseAgent(id_in="Ba1")
+
+    # Error thrown when no players available
+    try:
+        lad.match_players()
+        assert False
+    except RuntimeError:
+        pass
+
+    # Error thrown when only one player available
+    lad.add_player(ba1)
+    try:
+        lad.match_players()
+        assert False
+    except RuntimeError:
+        pass
+
+
 test_match_basic()
 test_match_func()
 test_run_game()
 test_get_players_sorted()
 test_selection_size()
+test_match_error()


### PR DESCRIPTION
Addresses Issue #150 

## Updates
`BaseLadder` match_players now raises `RuntimeError` when either
- No players are in the pool to match
- Only one player in the pool is available (no match can be found)

## Test Cases
`tests/ladder_tests/weighted_ladder_test.py`
- When 0 players are available in the `player_pool`, throw a RuntimeError
- When 1 player is available in the `player_pool`, throw a RuntimeError
- In cases when there are originally more than 3 players, running `match_players()` after the first set of players are matched (ie: only one player remains in the pool) throws a RuntimeError
