### PR TITLE
Refactor attack generation scope

### DIFF
--- a/agent/basic_planning_pokemon_agent.py
+++ b/agent/basic_planning_pokemon_agent.py
@@ -54,16 +54,14 @@ class BasicPlanningPokemonAgent(PokemonAgent):
         opp_opts = []
 
         # My possible attacks
-        posn = 0
-        for _ in self.game_state.gamestate["active"].moves:
-            player_opts.append(("ATTACK", posn))
-            posn += 1
+        self_can_switch, player_opts = self.game_state.gamestate["active"].possible_moves()
 
         # My possible switches
         posn = 0
-        for _ in self.game_state.gamestate["team"]:
-            player_opts.append(("SWITCH", posn))
-            posn += 1
+        if self_can_switch:
+            for _ in self.game_state.gamestate["team"]:
+                player_opts.append(("SWITCH", posn))
+                posn += 1
 
         # Opponent's possible attacks
         posn = 0

--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -77,9 +77,9 @@ class PokemonAgent(BaseAgent):
             switch = int(switch)
             response = "SWITCH", switch
         else:
-            move = uniform(0, len(moves))
-            move = int(move)
-            response = "ATTACK", move
+            move_ind = uniform(0, len(moves))
+            move_ind = int(move_ind)
+            response = moves[move_ind]
 
         return response
 

--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -69,7 +69,7 @@ class PokemonAgent(BaseAgent):
 
         """
         response = ()
-        active_can_switch, moves = self.game_state["active"].possible_moves()
+        active_can_switch, moves = self.game_state.gamestate["active"].possible_moves()
         can_switch = len(self.game_state.gamestate["team"]) > 0 and active_can_switch
 
         if can_switch and random() < 0.5:

--- a/agent/basic_pokemon_agent.py
+++ b/agent/basic_pokemon_agent.py
@@ -69,14 +69,15 @@ class PokemonAgent(BaseAgent):
 
         """
         response = ()
-        can_switch = len(self.game_state.gamestate["team"]) > 0
+        active_can_switch, moves = self.game_state["active"].possible_moves()
+        can_switch = len(self.game_state.gamestate["team"]) > 0 and active_can_switch
 
         if can_switch and random() < 0.5:
             switch = uniform(0, len(self.game_state.gamestate["team"]))
             switch = int(switch)
             response = "SWITCH", switch
         else:
-            move = uniform(0, len(self.game_state.gamestate["active"].moves))
+            move = uniform(0, len(moves))
             move = int(move)
             response = "ATTACK", move
 

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -234,6 +234,15 @@ class Pokemon:
         self.boosts[stat] = min(self.boosts[stat], 6)
         self.boosts[stat] = max(self.boosts[stat], -6)
 
+    def possible_moves(self):
+        """
+        Generate possible attacks this pokemon can make.
+
+        Returns:
+            List of possible moves, and boolean if it can switch.
+
+        """
+
 
 def default_boosts():
     """Generate dictionary with default boost levels."""

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -242,6 +242,13 @@ class Pokemon:
             List of possible moves, and boolean if it can switch.
 
         """
+        can_switch = True
+        possible_moves = []
+
+        for move in self.moves:
+            possible_moves.append(('ATTACK', self.moves.index(move)))
+
+        return can_switch, possible_moves
 
 
 def default_boosts():

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -212,6 +212,16 @@ def test_get_method():
     assert pkmn.get("DOOT") is None
 
 
+def test_possible_moves():
+    """Make sure possible_moves works properly."""
+    pkmn = Pokemon(name="spinda", moves=["tackle", "watergun"], level=50)
+    poke_can_switch, moves = pkmn.possible_moves()
+
+    assert poke_can_switch
+    assert moves
+    assert len(moves) == 2
+
+
 test_init()
 test_param_validation()
 test_stats_calculation()
@@ -219,3 +229,4 @@ test_getitem_validation()
 test_effective_stats()
 test_status()
 test_get_method()
+test_possible_moves()


### PR DESCRIPTION
Addresses Issue #154 

## Updates
Possible attack generation moved from Agent level logic to Pokemon logic.

## Test Cases
`tests/misc_tests/pokemon_test.py`
- A pokemon with two moves, no status conditions, no volatile status, and two moves _can_ switch, and make any one of its moves.
