### PR TITLE
Enhancement - Logs for single simulation in single folder

### DIFF
--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -1,6 +1,5 @@
 """Engine to run the turn of a pokemon game."""
 
-from math import floor
 from copy import deepcopy
 from uuid import uuid4
 

--- a/file_manager/log_writer.py
+++ b/file_manager/log_writer.py
@@ -113,7 +113,6 @@ def generate_file(filename, directory):
 
     """
     if not exists(join(config.LOG_DIR, directory)):
-        print("MAKING: {}".format(join(config.LOG_DIR, directory)))
         makedirs(join(config.LOG_DIR, directory))
 
     if directory:

--- a/file_manager/log_writer.py
+++ b/file_manager/log_writer.py
@@ -1,5 +1,6 @@
 """Log Manager Class."""
-from os.path import join
+from os.path import join, exists
+from os import makedirs
 
 from csv import writer
 
@@ -20,7 +21,7 @@ class LogWriter():
 
     """
 
-    def __init__(self, header, prefix=None):
+    def __init__(self, header, directory="", prefix=None):
         """
         Initialize LogWriter for a simulation.
 
@@ -42,7 +43,7 @@ class LogWriter():
             raise AttributeError("Header cannot be empty")
 
         self.filename = generate_filename(prefix)
-        self.output_file = generate_file(self.filename)
+        self.output_file = generate_file(self.filename, directory)
         self.output_csv = writer(self.output_file)
 
         self.header = header
@@ -100,7 +101,7 @@ def generate_filename(prefix):
     return filename
 
 
-def generate_file(filename):
+def generate_file(filename, directory):
     """
     Generate the file that will be used.
 
@@ -111,5 +112,13 @@ def generate_file(filename):
         File object with the name <filename>.
 
     """
-    file_ = join(config.LOG_DIR, filename)
+    if not exists(join(config.LOG_DIR, directory)):
+        print("MAKING: {}".format(join(config.LOG_DIR, directory)))
+        makedirs(join(config.LOG_DIR, directory))
+
+    if directory:
+        file_ = join(config.LOG_DIR, directory, filename)
+    else:
+        file_ = join(config.LOG_DIR, filename)
+
     return open(file_, mode="w", newline="")

--- a/simulation/base_simulation.py
+++ b/simulation/base_simulation.py
@@ -1,5 +1,6 @@
 """Class for simulation that everything inherits from."""
 
+from uuid import uuid4
 from time import time
 import json
 
@@ -28,8 +29,10 @@ class BaseSimulation():
             ladder_choice (int): Whether to use WeightedLadder (0) or RandomLadder (1)
                 for ladder matching.
             prefix (str): Prefix to use for these filenames.
+            directory (str): Directory in which to store simulation results.
 
         """
+        self.directory = kwargs.get("directory", uuid4())
         self.num_players = kwargs["num_players"]
         self.num_games = kwargs["num_games"]
         self.game = kwargs["game"]
@@ -75,7 +78,7 @@ class BaseSimulation():
 
         log_prefix = "{}Players".format(self.prefix)
 
-        self.player_log_writer = LogWriter(header, prefix=log_prefix)
+        self.player_log_writer = LogWriter(header, self.directory, prefix=log_prefix)
 
     def print_progress_bar(self, iter_num, start_time):
         """

--- a/simulation/base_simulation.py
+++ b/simulation/base_simulation.py
@@ -32,7 +32,7 @@ class BaseSimulation():
             directory (str): Directory in which to store simulation results.
 
         """
-        self.directory = kwargs.get("directory", uuid4())
+        self.directory = kwargs.get("directory", str(uuid4()))
         self.num_players = kwargs["num_players"]
         self.num_games = kwargs["num_games"]
         self.game = kwargs["game"]

--- a/simulation/pkmn_simulation.py
+++ b/simulation/pkmn_simulation.py
@@ -69,7 +69,7 @@ class PokemonSimulation(BaseLoggingSimulation):
         for conf in self.config:
             header.append(conf["agent_type"])
 
-        self.type_log_writer = LogWriter(header, prefix="PKMNTypes")
+        self.type_log_writer = LogWriter(header, prefix="PKMNTypes", directory=self.directory)
 
     def run(self):
         """Run this simulation."""

--- a/simulation/rps_simulation.py
+++ b/simulation/rps_simulation.py
@@ -115,4 +115,4 @@ class RPSSimulation(BaseLoggingSimulation):
             if self.proportions[4] != 0:
                 header.append("counter")
 
-        self.type_log_writer = LogWriter(header, prefix="RPSTypes")
+        self.type_log_writer = LogWriter(header, prefix="RPSTypes", directory=self.directory)


### PR DESCRIPTION
Addresses Issue #158 

## Updates
LogWriter now accept a `directory` argument to write its file to. This allows us to have a simulation-level folder and store all its configs in there, instead of having to sort a file by its date.

## Test Cases
N/A
