### PR TITLE
Enhancement ladder not removing from pool

### DIFF
--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -12,6 +12,7 @@ class BaseAgent():
         elo (int): Elo ranking for this agent.
         num_wins (int): Number of games won.
         num_losses (int): Number of games lost.
+        in_game (bool): If player is currently in a game.
 
     """
 
@@ -37,6 +38,7 @@ class BaseAgent():
         self.elo = 1000
         self.num_wins = 0
         self.num_losses = 0
+        self.in_game = False
 
     def hello(self):
         """Test Method."""

--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -54,6 +54,7 @@ class BaseLadder:
         # Check that player is not already in the pool
         for player_tuple in self.player_pool:
             if player_tuple[0].id == player.id:
+                player.in_game = False
                 self.player_pool.remove(player_tuple)
 
         # Add the player to the pool

--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -193,8 +193,7 @@ class BaseLadder:
         available_indexes = []
         num_players = len(self.player_pool)
         for player_ind in range(num_players):
-            if not self.player_pool[player_ind].in_game:
+            if not self.player_pool[player_ind][0].in_game:
                 available_indexes.append(player_ind)
 
-        print(available_indexes)
         return available_indexes

--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -138,9 +138,10 @@ class BaseLadder:
 
         """
         # Select that player's opponent (based on weighting function)
-        candidate_opponents = sorted(self.player_pool,
+        match_pool = self.available_players()
+        candidate_opponents = sorted(match_pool,
                                      key=lambda val: self.match_func(player, val),
-                                     reverse=True)[:min(self.selection_size, len(self.player_pool))]
+                                     reverse=True)[:min(self.selection_size, len(match_pool))]
 
         return candidate_opponents
 
@@ -158,6 +159,7 @@ class BaseLadder:
 
         """
         player, opp = self.match_players()
+
         player_copy = deepcopy(player)
         opp_copy = deepcopy(opp)
 

--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -187,3 +187,14 @@ class BaseLadder:
         winner.num_wins += 1
         loser.elo = new_loser_elo
         loser.num_losses += 1
+
+    def available_players(self):
+        """Return list of players available to match."""
+        available_indexes = []
+        num_players = len(self.player_pool)
+        for player_ind in range(num_players):
+            if not self.player_pool[player_ind].in_game:
+                available_indexes.append(player_ind)
+
+        print(available_indexes)
+        return available_indexes

--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -113,13 +113,13 @@ class BaseLadder:
         del available_players[available_ind]
         player.in_game = True
 
+        # Get that player's opponent
         candidate_opponents = self.get_candidate_matches(player, available_players)
 
         opponent_choice = randint(0, len(candidate_opponents)-1)
         opponent_pair = candidate_opponents[opponent_choice]
         opponent = opponent_pair[0]
-        opponent_ind = self.player_pool.index(opponent_pair)
-        del self.player_pool[opponent_ind]
+        opponent.in_game = True
 
         self.thread_lock.release()
 

--- a/ladder/base_ladder.py
+++ b/ladder/base_ladder.py
@@ -110,10 +110,10 @@ class BaseLadder:
         # Select a random player
         available_ind = randint(a=0, b=(len(available_players)-1))
         player = available_players[available_ind][0]
-        # del self.player_pool[player_ind]
+        del available_players[available_ind]
         player.in_game = True
 
-        candidate_opponents = self.get_candidate_matches(player)
+        candidate_opponents = self.get_candidate_matches(player, available_players)
 
         opponent_choice = randint(0, len(candidate_opponents)-1)
         opponent_pair = candidate_opponents[opponent_choice]
@@ -126,19 +126,25 @@ class BaseLadder:
         self.num_turns += 1
         return (player, opponent)
 
-    def get_candidate_matches(self, player):
+    def get_candidate_matches(self, player, available_players=None):
         """
         Get the selection of players who are closest to <player>.
 
         Args:
             player (BaseAgent): Player for whom we are matching.
+            match_pool (list): List of players from whom to choose.
 
         Returns:
             List of length self.selection_size of potential opponents.
 
         """
         # Select that player's opponent (based on weighting function)
-        match_pool = self.available_players()
+        match_pool = None
+        if available_players is None:
+            match_pool = self.available_players()
+        else:
+            match_pool = available_players
+
         candidate_opponents = sorted(match_pool,
                                      key=lambda val: self.match_func(player, val),
                                      reverse=True)[:min(self.selection_size, len(match_pool))]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask==1.0.2
 idna==2.8
 isort==4.3.4
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2>=2.10.1
 kiwisolver==1.0.1
 lazy-object-proxy==1.3.1
 MarkupSafe==1.1.0
@@ -28,6 +28,6 @@ requests==2.21.0
 six==1.12.0
 snowballstemmer==1.2.1
 typed-ast==1.2.0
-urllib3==1.24.1
+urllib3>=1.24.2
 Werkzeug==0.14.1
 wrapt==1.11.1

--- a/tests/agent_tests/base_agent_test.py
+++ b/tests/agent_tests/base_agent_test.py
@@ -10,6 +10,7 @@ def test_init():
     assert ba1.num_wins == 0
     assert ba1.num_losses == 0
     assert ba1.type == "Pew"
+    assert ba1.in_game == False
 
 
 def test_win_loss():

--- a/tests/agent_tests/base_agent_test.py
+++ b/tests/agent_tests/base_agent_test.py
@@ -10,7 +10,7 @@ def test_init():
     assert ba1.num_wins == 0
     assert ba1.num_losses == 0
     assert ba1.type == "Pew"
-    assert ba1.in_game == False
+    assert ba1.in_game is False
 
 
 def test_win_loss():

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -1,6 +1,7 @@
 """Test for functions of BaseLadder."""
 
 from agent.base_agent import BaseAgent
+from battle_engine.coinflip import CoinFlipEngine
 from ladder.base_ladder import BaseLadder
 from tests.ladder_tests.ladder_test_helpers import mock_match_func
 
@@ -103,8 +104,44 @@ def test_match_error():
         pass
 
 
+def test_run_game():
+    """Test run_game functions properly."""
+    # Set up variables
+    ba1 = BaseAgent()
+    ba2 = BaseAgent()
+    cfe = CoinFlipEngine()
+    lad = BaseLadder(game=cfe)
+    lad.match_func = mock_match_func
+
+    # Add players to the ladder
+    lad.add_player(ba1)
+    lad.add_player(ba2)
+
+    # Run the game
+    lad.run_game()
+
+    # Check that the ladder updated properly
+    players = lad.get_players()
+
+    player1 = players[0]
+    player2 = players[1]
+
+    # Only one elo value changes
+    assert((player1.elo > 1000 and player2.elo == 1000) or
+           (player1.elo == 1000 and player2.elo > 1000))
+
+    # Someone won the game
+    assert((player1.num_wins == 0 and player2.num_wins == 1) or
+           (player1.num_wins == 1 and player2.num_wins == 0))
+
+    # Someone lost the game
+    assert((player1.num_losses == 0 and player2.num_losses == 1) or
+           (player1.num_losses == 1 and player2.num_losses == 0))
+
+
 test_add()
 test_duplicate_add()
 test_available_players()
 test_match_basic()
 test_match_error()
+test_run_game()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -2,7 +2,7 @@
 
 from agent.base_agent import BaseAgent
 from ladder.base_ladder import BaseLadder
-
+from tests.ladder_tests.ladder_test_helpers import mock_match_func
 
 def test_add():
     """Basic test for ladder add_player method."""
@@ -46,6 +46,31 @@ def test_available_players():
     assert available_players[0] == (ba2, 0)
 
 
+def test_match_basic():
+    """Test that match functions properly."""
+    # Set up variables
+    lad = BaseLadder()
+    ba1 = BaseAgent()
+    ba2 = BaseAgent()
+
+    # Use fake match function
+    lad.match_func = mock_match_func
+
+    # Add the players to the ladder
+    lad.add_player(ba1)
+    lad.add_player(ba2)
+
+    # Generate a match (should be ba1 and ba2)
+    _ = lad.match_players()
+
+    # Assert that players get removed from player pool
+    assert not lad.available_players()
+    assert lad.num_turns == 1
+    for player, _ in lad.player_pool:
+        assert player.in_game
+
+
 test_add()
 test_duplicate_add()
 test_available_players()
+test_match_basic()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -139,9 +139,37 @@ def test_run_game():
            (player1.num_losses == 1 and player2.num_losses == 0))
 
 
+def test_get_players_sorted():
+    """Run get_players with sorted flag to true."""
+    # Set up variables
+    ba1 = BaseAgent()
+    ba2 = BaseAgent()
+    cfe = CoinFlipEngine()
+    lad = BaseLadder(game=cfe)
+    lad.match_func = mock_match_func
+
+    # Add players to the ladder
+    lad.add_player(ba1)
+    lad.add_player(ba2)
+
+    # Run the game
+    lad.run_game()
+
+    # Check that the results are sorted in ascending elo
+    players = lad.get_players(sort=True)
+
+    player1 = players[0]
+    player2 = players[1]
+
+    assert player1.elo > player2.elo
+    assert (player1.num_wins == 1 and player2.num_wins == 0)
+    assert (player1.num_losses == 0 and player2.num_losses == 1)
+
+
 test_add()
 test_duplicate_add()
 test_available_players()
 test_match_basic()
 test_match_error()
 test_run_game()
+test_get_players_sorted()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -32,5 +32,22 @@ def test_no_duplicates():
     assert False
 
 
+def test_available_players():
+    """Test that available players picks out players not in games."""
+    lad = BaseLadder()
+    ba1 = BaseAgent()
+    ba2 = BaseAgent()
+
+    # No players are in games, so all available
+    lad.add_player(ba1)
+    lad.add_player(ba2)
+    assert len(lad.available_players()) == 2
+
+    # One player is taken
+    ba1.in_game = True
+    assert len(lad.available_players()) == 1
+
+
 test_add()
 test_no_duplicates()
+test_available_players()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -47,7 +47,7 @@ def test_available_players():
     ba1.in_game = True
     available_players = lad.available_players()
     assert len(available_players) == 1
-    assert available_players[0] == 1
+    assert available_players[0] == (ba2, 0)
 
 
 test_add()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -45,7 +45,9 @@ def test_available_players():
 
     # One player is taken
     ba1.in_game = True
-    assert len(lad.available_players()) == 1
+    available_players = lad.available_players()
+    assert len(available_players) == 1
+    assert available_players[0] == 1
 
 
 test_add()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -16,20 +16,16 @@ def test_add():
     assert len(lad.player_pool) == 2
 
 
-def test_no_duplicates():
+def test_duplicate_add():
     """Test that same player cannot exist twice on ladder."""
     lad = BaseLadder()
     ba1 = BaseAgent()
     lad.add_player(ba1)
 
-    try:
-        lad.add_player(ba1)
-    except ValueError:
-        # Ladder throws a ValueError if a duplicate player exists
-        # We want to be here
-        return
+    lad.num_turns = 50
 
-    assert False
+    lad.add_player(ba1)
+    assert lad.player_pool[0][1] == 50
 
 
 def test_available_players():
@@ -51,5 +47,5 @@ def test_available_players():
 
 
 test_add()
-test_no_duplicates()
+test_duplicate_add()
 test_available_players()

--- a/tests/ladder_tests/base_ladder_test.py
+++ b/tests/ladder_tests/base_ladder_test.py
@@ -70,7 +70,41 @@ def test_match_basic():
         assert player.in_game
 
 
+def test_match_error():
+    """Ensure RuntimeError is thrown when no players available to match."""
+    lad = BaseLadder()
+    ba1 = BaseAgent(id_in="Ba1")
+    lad.match_func = mock_match_func
+
+    # Error thrown when no players available
+    try:
+        lad.match_players()
+        assert False
+    except RuntimeError:
+        pass
+
+    # Error thrown when only one player available
+    lad.add_player(ba1)
+    try:
+        lad.match_players()
+        assert False
+    except RuntimeError:
+        pass
+
+    # Originally enough players, but not enough afterwards
+    for _ in range(2):
+        lad.add_player(BaseAgent())
+
+    try:
+        lad.match_players()  # 3 players in pool
+        lad.match_players()  # Only 1 player in pool
+        assert False
+    except RuntimeError:
+        pass
+
+
 test_add()
 test_duplicate_add()
 test_available_players()
 test_match_basic()
+test_match_error()

--- a/tests/ladder_tests/ladder_test_helpers.py
+++ b/tests/ladder_tests/ladder_test_helpers.py
@@ -1,0 +1,5 @@
+"""Helper functions for Ladder Tests."""
+
+def mock_match_func(*_, **__):
+    """Overriden match function."""
+    return 3

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -48,7 +48,7 @@ def test_match_basic():
     _ = lad.match_players()
 
     # Assert that players get removed from ladder
-    assert not lad.player_pool
+    assert not lad.available_players()
     assert lad.num_turns == 1
 
 

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -125,40 +125,7 @@ def test_selection_size():
     assert len(lad.get_candidate_matches(base_player)) == 15
 
 
-def test_match_error():
-    """Ensure RuntimeError is thrown when no players available to match."""
-    lad = WeightedLadder()
-    ba1 = BaseAgent(id_in="Ba1")
-
-    # Error thrown when no players available
-    try:
-        lad.match_players()
-        assert False
-    except RuntimeError:
-        pass
-
-    # Error thrown when only one player available
-    lad.add_player(ba1)
-    try:
-        lad.match_players()
-        assert False
-    except RuntimeError:
-        pass
-
-    # Originally enough players, but not enough afterwards
-    for _ in range(2):
-        lad.add_player(BaseAgent())
-
-    try:
-        lad.match_players()  # 3 players in pool
-        lad.match_players()  # Only 1 player in pool
-        assert False
-    except RuntimeError:
-        pass
-
-
 test_match_func()
 test_run_game()
 test_get_players_sorted()
 test_selection_size()
-test_match_error()

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -47,9 +47,11 @@ def test_match_basic():
     # Generate a match (should be ba1 and ba2)
     _ = lad.match_players()
 
-    # Assert that players get removed from ladder
+    # Assert that players get removed from player pool
     assert not lad.available_players()
     assert lad.num_turns == 1
+    for player, _ in lad.player_pool:
+        assert player.in_game
 
 
 def test_run_game():

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -2,7 +2,6 @@
 
 from agent.base_agent import BaseAgent
 from ladder.weighted_ladder import WeightedLadder
-from battle_engine.coinflip import CoinFlipEngine
 
 def test_match_func():
     """Test the match_func to make sure it works."""
@@ -30,32 +29,6 @@ def test_match_func():
 
     # Higher elo players got matched together
     assert (match2.id == ba1.id or match2.id == ba2.id)
-
-
-def test_get_players_sorted():
-    """Run get_players with sorted flag to true."""
-    # Set up variables
-    ba1 = BaseAgent()
-    ba2 = BaseAgent()
-    cfe = CoinFlipEngine()
-    lad = WeightedLadder(cfe)
-
-    # Add players to the ladder
-    lad.add_player(ba1)
-    lad.add_player(ba2)
-
-    # Run the game
-    lad.run_game()
-
-    # Check that the results are sorted in ascending elo
-    players = lad.get_players(sort=True)
-
-    player1 = players[0]
-    player2 = players[1]
-
-    assert player1.elo > player2.elo
-    assert (player1.num_wins == 1 and player2.num_wins == 0)
-    assert (player1.num_losses == 0 and player2.num_losses == 1)
 
 
 def test_selection_size():
@@ -91,5 +64,4 @@ def test_selection_size():
 
 
 test_match_func()
-test_get_players_sorted()
 test_selection_size()

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -4,7 +4,6 @@ from agent.base_agent import BaseAgent
 from ladder.weighted_ladder import WeightedLadder
 from battle_engine.coinflip import CoinFlipEngine
 
-
 def test_match_func():
     """Test the match_func to make sure it works."""
     # Set up variables
@@ -31,40 +30,6 @@ def test_match_func():
 
     # Higher elo players got matched together
     assert (match2.id == ba1.id or match2.id == ba2.id)
-
-
-def test_run_game():
-    """Test run_game functions properly."""
-    # Set up variables
-    ba1 = BaseAgent()
-    ba2 = BaseAgent()
-    cfe = CoinFlipEngine()
-    lad = WeightedLadder(game=cfe)
-
-    # Add players to the ladder
-    lad.add_player(ba1)
-    lad.add_player(ba2)
-
-    # Run the game
-    lad.run_game()
-
-    # Check that the ladder updated properly
-    players = lad.get_players()
-
-    player1 = players[0]
-    player2 = players[1]
-
-    # Only one elo value changes
-    assert((player1.elo > 1000 and player2.elo == 1000) or
-           (player1.elo == 1000 and player2.elo > 1000))
-
-    # Someone won the game
-    assert((player1.num_wins == 0 and player2.num_wins == 1) or
-           (player1.num_wins == 1 and player2.num_wins == 0))
-
-    # Someone lost the game
-    assert((player1.num_losses == 0 and player2.num_losses == 1) or
-           (player1.num_losses == 1 and player2.num_losses == 0))
 
 
 def test_get_players_sorted():
@@ -126,6 +91,5 @@ def test_selection_size():
 
 
 test_match_func()
-test_run_game()
 test_get_players_sorted()
 test_selection_size()

--- a/tests/ladder_tests/weighted_ladder_test.py
+++ b/tests/ladder_tests/weighted_ladder_test.py
@@ -33,27 +33,6 @@ def test_match_func():
     assert (match2.id == ba1.id or match2.id == ba2.id)
 
 
-def test_match_basic():
-    """Test that match functions properly."""
-    # Set up variables
-    lad = WeightedLadder()
-    ba1 = BaseAgent()
-    ba2 = BaseAgent()
-
-    # Add the players to the ladder
-    lad.add_player(ba1)
-    lad.add_player(ba2)
-
-    # Generate a match (should be ba1 and ba2)
-    _ = lad.match_players()
-
-    # Assert that players get removed from player pool
-    assert not lad.available_players()
-    assert lad.num_turns == 1
-    for player, _ in lad.player_pool:
-        assert player.in_game
-
-
 def test_run_game():
     """Test run_game functions properly."""
     # Set up variables
@@ -178,7 +157,6 @@ def test_match_error():
         pass
 
 
-test_match_basic()
 test_match_func()
 test_run_game()
 test_get_players_sorted()


### PR DESCRIPTION
Addresses Issue #162

## Updates
The ladder no longer removes players from the player pool. It instead sets an `in_game` flag. In addition, instead of checking against `player_pool`, it checks against the `available_players`.
The purpose of this change is so that way when Elo rankings are calculated for generating stats, they are not affected by the fact that some players may be in games.

## Test Cases
`agent_tests/base_agent_test.py`
- Tests that `in_game` is defaulted to `False`

`ladder_tests/base_ladder_test.py`
- When two players with `in_game = False`, the `available_players()` function returns both of them
- When one players with `in_game = False`, the `available_players()` function returns one of them