### PR TITLE
Volatile Statuses - Batch 1

### DIFF
--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -270,7 +270,7 @@ class PokemonEngine():
         Args:
             attacker (str): The player ("player1" or "player2")
                 who is attacking.
-            move (dict): The data for the move that is being done.
+            move (Move): The data for the move that is being done.
 
         Returns:
             List of the information on the attack that was just done.
@@ -319,6 +319,9 @@ class PokemonEngine():
                 return None
         # Check for flinch
         if "flinch" in atk_poke.volatile_status:
+            return None
+        # Check for Taunt when status move chosen
+        if "taunt" in atk_poke.volatile_status and move["category"] == "Status":
             return None
 
         # Check if the move even hit...

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -182,16 +182,8 @@ class PokemonEngine():
                 self.update_gamestates(player1, player2)
 
         # Remove volatile statuses if turn is passed
-        for poke in [self.game_state["player1"]["active"], self.game_state["player2"]["active"]]:
-            if poke is None:
-                continue
-
-            active_vs = list(poke.volatile_status.keys())
-            for vol_status in active_vs:
-                if vol_status in SINGLE_TURN_VS:
-                    del poke.volatile_status[vol_status]
-                elif vol_status in TWO_TURN_VS and poke.volatile_status[vol_status] == 2:
-                    del poke.volatile_status[vol_status]
+        remove_end_of_turn_vs(self.game_state["player1"]["active"])
+        remove_end_of_turn_vs(self.game_state["player2"]["active"])
 
         return outcome, turn_info
 
@@ -551,6 +543,25 @@ class PokemonEngine():
             new_line["move"] = turn["move"]["id"]
             new_line["damage"] = turn["damage"]
             turn_logwriter.write_line(new_line)
+
+
+def remove_end_of_turn_vs(poke):
+    """
+    Remove Volatile Statusses at the end of a turn (if appropriate)
+
+    Args:
+        poke (Pokemon): Pokemon for whom to remove the VS's
+
+    """
+    if poke is None:
+        return
+
+    active_vs = list(poke.volatile_status.keys())
+    for vol_status in active_vs:
+        if vol_status in SINGLE_TURN_VS:
+            del poke.volatile_status[vol_status]
+        elif vol_status in TWO_TURN_VS and poke.volatile_status[vol_status] == 2:
+            del poke.volatile_status[vol_status]
 
 
 def anonymize_gamestate_helper(data):

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -148,8 +148,14 @@ class PokemonEngine():
                 info["attacker"] = player_id_dict[info.get("attacker")]
                 info["defender"] = player_id_dict[info.get("defender")]
 
+        # TODO: Verify exact order these come in
+        # TODO: Check for fainting 
         self.game_state["player1"]["active"].apply_status_damage()
         self.game_state["player2"]["active"].apply_status_damage()
+
+        self.game_state["player1"]["active"].apply_endofturn_volatile_status_effects()
+        self.game_state["player2"]["active"].apply_endofturn_volatile_status_effects()
+
 
         player1.new_info(turn_info)
         player2.new_info(turn_info)

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -547,7 +547,7 @@ class PokemonEngine():
 
 def remove_end_of_turn_vs(poke):
     """
-    Remove Volatile Statusses at the end of a turn (if appropriate)
+    Remove Volatile Statusses at the end of a turn (if appropriate).
 
     Args:
         poke (Pokemon): Pokemon for whom to remove the VS's

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -323,6 +323,16 @@ class PokemonEngine():
         # Check for Taunt when status move chosen
         if "taunt" in atk_poke.volatile_status and move["category"] == "Status":
             return None
+        # Check for confusion
+        if "confusion" in atk_poke.volatile_status:
+            # Check if confusion wears off
+            if atk_poke.volatile_status["confusion"] > 4 or random() > 0.33:
+                del atk_poke.volatile_status["confusion"]
+
+            # Attacker hits themself in confusion
+            atk_poke.current_hp -= atk_poke.confusion_damage()
+
+            return None
 
         # Check if the move even hit...
         damage = 0

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -342,6 +342,9 @@ class PokemonEngine():
                 atk_poke.current_hp -= damage
 
                 could_move = False
+        # Check for attract
+        if "attract" in atk_poke.volatile_status and random() < 0.5:
+            could_move = False
 
         if move_hits and could_move:
             # Do Damage

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -317,6 +317,9 @@ class PokemonEngine():
             else:
                 atk_poke.status_counter += 1
                 return None
+        # Check for flinch
+        if "flinch" in atk_poke.volatile_status:
+            return None
 
         # Check if the move even hit...
         damage = 0

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -329,10 +329,12 @@ class PokemonEngine():
             if atk_poke.volatile_status["confusion"] > 4 or random() > 0.33:
                 del atk_poke.volatile_status["confusion"]
 
-            # Attacker hits themself in confusion
-            atk_poke.current_hp -= atk_poke.confusion_damage()
+            # Check if attacker hits themself in confusion
+            if random() > 0.5:
+                damage, _ = atk_poke.confusion_damage()
+                atk_poke.current_hp -= damage
 
-            return None
+                return None
 
         # Check if the move even hit...
         damage = 0

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -297,7 +297,6 @@ class PokemonEngine():
         atk_poke = self.game_state[attacker]["active"]
         def_poke = self.game_state[defender]["active"]
 
-
         # Set up variables for damage
         damage = 0
         critical_hit = False
@@ -388,8 +387,6 @@ class PokemonEngine():
         results["def_poke"] = def_poke.name
         results["move_hits"] = move_hits
         return [results]
-
-
 
     def turn_both_attack(self, move1, move2):
         """
@@ -604,6 +601,7 @@ def remove_end_of_turn_vs(poke):
 
         if delete_flag:
             del poke.volatile_status[vol_status]
+
 
 def anonymize_gamestate_helper(data):
     """

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -370,7 +370,7 @@ class PokemonEngine():
             elif isinstance(atk_poke.volatile_status[vol_status], dict) and \
                 atk_poke.volatile_status[vol_status].get("counter") is not None:
                 atk_poke.volatile_status[vol_status]["counter"] += 1
-            elif vol_status != "substitute":
+            elif vol_status not in ["substitute", "autotomize"]:
                 atk_poke.volatile_status[vol_status] += 1
 
         if not could_move:

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -367,6 +367,9 @@ class PokemonEngine():
                 atk_poke.volatile_status[vol_status]["counter"] += 1
             elif vol_status == "torment":
                 atk_poke.volatile_status[vol_status] = move
+            elif isinstance(atk_poke.volatile_status[vol_status], dict) and \
+                atk_poke.volatile_status[vol_status].get("counter") is not None:
+                atk_poke.volatile_status[vol_status]["counter"] += 1
             elif vol_status != "substitute":
                 atk_poke.volatile_status[vol_status] += 1
 
@@ -587,11 +590,20 @@ def remove_end_of_turn_vs(poke):
 
     active_vs = list(poke.volatile_status.keys())
     for vol_status in active_vs:
-        if vol_status in SINGLE_TURN_VS:
-            del poke.volatile_status[vol_status]
+        delete_flag = False
+        if isinstance(poke.volatile_status[vol_status], dict) and\
+            "counter" in poke.volatile_status[vol_status]:
+            num_turns = poke.volatile_status[vol_status]["counter"]
+            if "duration" in poke.volatile_status[vol_status].get("effect", {}):
+                if num_turns > poke.volatile_status[vol_status]["effect"]["duration"]:
+                    delete_flag = True
+        elif vol_status in SINGLE_TURN_VS:
+            delete_flag = True
         elif vol_status in TWO_TURN_VS and poke.volatile_status[vol_status] == 2:
-            del poke.volatile_status[vol_status]
+            delete_flag = True
 
+        if delete_flag:
+            del poke.volatile_status[vol_status]
 
 def anonymize_gamestate_helper(data):
     """

--- a/battle_engine/pokemon_engine.py
+++ b/battle_engine/pokemon_engine.py
@@ -349,6 +349,8 @@ class PokemonEngine():
         for vol_status in atk_poke.volatile_status:
             if vol_status == "lockedmove":
                 atk_poke.volatile_status[vol_status]["counter"] += 1
+            elif vol_status == "torment":
+                atk_poke.volatile_status[vol_status] = move
             elif vol_status != "substitute":
                 atk_poke.volatile_status[vol_status] += 1
 

--- a/interface/main.py
+++ b/interface/main.py
@@ -81,8 +81,8 @@ def set_engine():
 
         # Set the response data
         response["outcome"] = ENGINE.win_condition_met()
-        response["player_active"] = ENGINE.game_state["player1"]["active"].__dict__
-        response["opp_active"] = ENGINE.game_state["player2"]["active"].__dict__
+        response["player_active"] = ENGINE.game_state["player1"]["active"].to_json()
+        response["opp_active"] = ENGINE.game_state["player2"]["active"].to_json()
         response["player_opts"] = process_opts(PLAYER, PLAYER.generate_possibilities()[0])
         response["gamestate"] = PLAYER.game_state.to_json()
 

--- a/interface/main.py
+++ b/interface/main.py
@@ -104,12 +104,17 @@ def make_move():
     response["turn_info"] = turn_info
     response["outcome"] = outcome
 
+    # Make moves in turn_info JSON serializable
+    for turn_datum in turn_info:
+        turn_datum["move"] = turn_datum["move"].to_json()
+
     if not outcome["finished"]:
         response["gamestate"] = PLAYER.game_state.to_json()
-        response["player_active"] = ENGINE.game_state["player1"]["active"].__dict__
-        response["opp_active"] = ENGINE.game_state["player2"]["active"].__dict__
+        response["player_active"] = ENGINE.game_state["player1"]["active"].to_json()
+        response["opp_active"] = ENGINE.game_state["player2"]["active"].to_json()
         response["player_opts"] = process_opts(PLAYER, PLAYER.generate_possibilities()[0])
 
+    print(response)
     return jsonify(response)
 
 

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -337,6 +337,12 @@ class VolatileStatusMove(BaseMove):
             # Handle Torment (default to None)
             if self.volatile_status == "torment":
                 defender.set_volatile_status(self.volatile_status, None)
+            # Moves with effect
+            if self.effect:
+                vol_stat = {}
+                vol_stat["effect"] = self.effect
+                vol_stat["counter"] = 0
+                defender.set_volatile_status(self.volatile_status, vol_stat)
             # All other cases
             else:
                 defender.set_volatile_status(self.volatile_status)

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -316,6 +316,9 @@ class VolatileStatusMove(BaseMove):
             if attacker.current_hp > substitute_hp:
                 attacker.set_volatile_status("substitute", substitute_hp)
                 attacker.current_hp -= substitute_hp
+        # Handle Torment (default to None)
+        if self.volatile_status == "torment":
+            defender.volatile_status = None
         # Handle applying volatile statuses to the attacker
         elif self._self and "volatileStatus" in self._self:
             if self._self["volatileStatus"] not in attacker.volatile_status:

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -317,8 +317,8 @@ class VolatileStatusMove(BaseMove):
                 attacker.set_volatile_status("substitute", substitute_hp)
                 attacker.current_hp -= substitute_hp
         # Handle Torment (default to None)
-        if self.volatile_status == "torment":
-            defender.volatile_status = None
+        if self.volatile_status == "torment" and "torment" not in defender.volatile_status:
+            defender.volatile_status[self.volatile_status] = None
         # Handle applying volatile statuses to the attacker
         elif self._self and "volatileStatus" in self._self:
             if self._self["volatileStatus"] not in attacker.volatile_status:

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -213,6 +213,10 @@ class BaseMove():
 
         return 100*random() < move_acc
 
+    def to_json(self):
+        """Return JSON serializable version of self."""
+        return self.__dict__
+
     def get(self, key, default=None):
         """
         Extend __getitem__ to have defaults.

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -338,7 +338,6 @@ class VolatileStatusMove(BaseMove):
                 defender.set_volatile_status(self.volatile_status)
 
 
-
 class HealingMove(BaseMove):
     """Class for Healing Moves."""
 

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -342,7 +342,22 @@ class VolatileStatusMove(BaseMove):
                 attacker.set_volatile_status(self.volatile_status)
         # Handle applying volatile status to defending pokemon
         elif self.volatile_status and self.volatile_status not in defender.volatile_status:
-            apply_volatile_status_defender(self, defender)
+            self._apply_volatile_status_defender(defender)
+
+    def _apply_volatile_status_defender(self, defender):
+        """Apply the volatile statuse effect to the defender."""
+        # Handle Torment (default to None)
+        if self.volatile_status == "torment":
+            defender.set_volatile_status(self.volatile_status, None)
+        # Moves with effect
+        if self.effect:
+            vol_stat = {}
+            vol_stat["effect"] = self.effect
+            vol_stat["counter"] = 0
+            defender.set_volatile_status(self.volatile_status, vol_stat)
+        # All other cases
+        else:
+            defender.set_volatile_status(self.volatile_status)
 
 
 class HealingMove(BaseMove):
@@ -424,19 +439,3 @@ def generate_move(move_config):
     output = NewClass(**move_config)
 
     return output
-
-
-def apply_volatile_status_defender(move, defender):
-    """Apply the volatile statuse effect to the defender."""
-    # Handle Torment (default to None)
-    if move.volatile_status == "torment":
-        defender.set_volatile_status(move.volatile_status, None)
-    # Moves with effect
-    if move.effect:
-        vol_stat = {}
-        vol_stat["effect"] = move.effect
-        vol_stat["counter"] = 0
-        defender.set_volatile_status(move.volatile_status, vol_stat)
-    # All other cases
-    else:
-        defender.set_volatile_status(move.volatile_status)

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -126,7 +126,7 @@ class BaseMove():
         # Only apply crits & random range when not testing
         if not testing:
             # Critical Hit
-            if random() < 0.0625:
+            if random() < 0.0625 or "laserfocus" in attacker.volatile_status:
                 critical_hit = True
                 modifier = modifier * 1.5
 

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -331,6 +331,7 @@ class VolatileStatusMove(BaseMove):
                 else:
                     attacker.set_volatile_status(self._self["volatileStatus"])
         elif self.target == "self" and self.volatile_status:
+            # Handle Autotomize
             if self.volatile_status == "autotomize":
                 if "autotomize" in attacker.volatile_status:
                     attacker.set_volatile_status(self.volatile_status,
@@ -341,18 +342,7 @@ class VolatileStatusMove(BaseMove):
                 attacker.set_volatile_status(self.volatile_status)
         # Handle applying volatile status to defending pokemon
         elif self.volatile_status and self.volatile_status not in defender.volatile_status:
-            # Handle Torment (default to None)
-            if self.volatile_status == "torment":
-                defender.set_volatile_status(self.volatile_status, None)
-            # Moves with effect
-            if self.effect:
-                vol_stat = {}
-                vol_stat["effect"] = self.effect
-                vol_stat["counter"] = 0
-                defender.set_volatile_status(self.volatile_status, vol_stat)
-            # All other cases
-            else:
-                defender.set_volatile_status(self.volatile_status)
+            apply_volatile_status_defender(self, defender)
 
 
 class HealingMove(BaseMove):
@@ -434,3 +424,19 @@ def generate_move(move_config):
     output = NewClass(**move_config)
 
     return output
+
+
+def apply_volatile_status_defender(move, defender):
+    """Apply the volatile statuse effect to the defender."""
+    # Handle Torment (default to None)
+    if move.volatile_status == "torment":
+        defender.set_volatile_status(move.volatile_status, None)
+    # Moves with effect
+    if move.effect:
+        vol_stat = {}
+        vol_stat["effect"] = move.effect
+        vol_stat["counter"] = 0
+        defender.set_volatile_status(move.volatile_status, vol_stat)
+    # All other cases
+    else:
+        defender.set_volatile_status(move.volatile_status)

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -331,7 +331,14 @@ class VolatileStatusMove(BaseMove):
                 else:
                     attacker.set_volatile_status(self._self["volatileStatus"])
         elif self.target == "self" and self.volatile_status:
-            attacker.set_volatile_status(self.volatile_status)
+            if self.volatile_status == "autotomize":
+                if "autotomize" in attacker.volatile_status:
+                    attacker.set_volatile_status(self.volatile_status,
+                                                 attacker.volatile_status[self.volatile_status] + 1)
+                else:
+                    attacker.set_volatile_status(self.volatile_status, 1)
+            else:
+                attacker.set_volatile_status(self.volatile_status)
         # Handle applying volatile status to defending pokemon
         elif self.volatile_status and self.volatile_status not in defender.volatile_status:
             # Handle Torment (default to None)

--- a/pokemon_helpers/moves.py
+++ b/pokemon_helpers/moves.py
@@ -316,9 +316,6 @@ class VolatileStatusMove(BaseMove):
             if attacker.current_hp > substitute_hp:
                 attacker.set_volatile_status("substitute", substitute_hp)
                 attacker.current_hp -= substitute_hp
-        # Handle Torment (default to None)
-        if self.volatile_status == "torment" and "torment" not in defender.volatile_status:
-            defender.volatile_status[self.volatile_status] = None
         # Handle applying volatile statuses to the attacker
         elif self._self and "volatileStatus" in self._self:
             if self._self["volatileStatus"] not in attacker.volatile_status:
@@ -333,7 +330,12 @@ class VolatileStatusMove(BaseMove):
             attacker.set_volatile_status(self.volatile_status)
         # Handle applying volatile status to defending pokemon
         elif self.volatile_status and self.volatile_status not in defender.volatile_status:
-            defender.set_volatile_status(self.volatile_status)
+            # Handle Torment (default to None)
+            if self.volatile_status == "torment":
+                defender.set_volatile_status(self.volatile_status, None)
+            # All other cases
+            else:
+                defender.set_volatile_status(self.volatile_status)
 
 
 

--- a/pokemon_helpers/pkmn_player_gamestate.py
+++ b/pokemon_helpers/pkmn_player_gamestate.py
@@ -1,5 +1,6 @@
 """Class defining an Engine's Game State."""
 
+from copy import deepcopy
 from config import POKEMON_DATA
 
 from pokemon_helpers.pokemon import Pokemon
@@ -428,7 +429,13 @@ class PokemonPlayerGameState:
         output["player"]["team"] = [pkmn.to_json() for pkmn in self.gamestate["team"]]
 
         # Add opponent's info
-        output["opponent"] = self.opp_gamestate
+        output["opponent"] = deepcopy(self.opp_gamestate)
+        for poke_moves in output["opponent"]["moves"]:
+            temp_arr = []
+            for move in output["opponent"]["moves"][poke_moves]:
+                temp_arr.append(move.to_json())
+
+            output["opponent"]["moves"][poke_moves] = temp_arr
 
         return output
 

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -258,9 +258,10 @@ class Pokemon:
         can_switch = True
         possible_moves = []
 
-        invalid_moves = []
+        invalid_moves = set()
         # Calculate invalid moves
-
+        if "torment" in self.volatile_status:
+            invalid_moves.add(self.volatile_status["torment"])
 
         for move in self.moves:
             if move not in invalid_moves:

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -321,6 +321,7 @@ class Pokemon:
         # User's weight cannot go below 0.1 KG
         return max(mod_weight, 0.1)
 
+
 def default_boosts():
     """Generate dictionary with default boost levels."""
     boost_dict = {}

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -276,6 +276,11 @@ class Pokemon:
             for move in self.moves:
                 if move.category == "Status":
                     invalid_moves.add(move)
+        if "healblock" in self.volatile_status:
+            # Cannot use healing moves under healblock
+            for move in self.moves:
+                if move.heal is not None:
+                    invalid_moves.add(move)
 
         # Based on invalid moves, generate possible moves
         for move in self.moves:

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -332,8 +332,9 @@ class Pokemon:
         if "aquaring" in self.volatile_status:
             hp_change += floor(self.max_hp * 1/16)
 
+        # Adjust HP, make sure don't overflow
         self.current_hp += hp_change
-        self.current_hp = min((self.current_hp, self.max_hp))
+        self.current_hp -= max((self.current_hp - self.max_hp, 0))
 
 
 def default_boosts():

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -228,7 +228,15 @@ class Pokemon:
 
     def to_json(self):
         """Return JSON serializable version of self."""
-        return self.__dict__
+        output_dict = dict(self.__dict__)
+
+        serialized_moves = []
+        for move in output_dict["moves"]:
+            serialized_moves.append(move.to_json())
+
+        output_dict["moves"] = serialized_moves
+
+        return output_dict
 
     def set_boost(self, stat, stages):
         """

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -269,6 +269,7 @@ class Pokemon:
 
         # No valid moves
         if not possible_moves:
+            # TODO: Implement Struggle Logic
             raise NotImplementedError("Should Struggle, not implemented yet")
 
         return can_switch, possible_moves

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -269,7 +269,7 @@ class Pokemon:
 
         # No valid moves
         if not possible_moves:
-            raise RuntimeError("NO VALID MOVES")
+            raise NotImplementedError("Should Struggle, not implemented yet")
 
         return can_switch, possible_moves
 

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -269,7 +269,6 @@ class Pokemon:
                 if move.category == "Status":
                     invalid_moves.add(move)
 
-
         # Based on invalid moves, generate possible moves
         for move in self.moves:
             if move not in invalid_moves:

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -258,8 +258,17 @@ class Pokemon:
         can_switch = True
         possible_moves = []
 
+        invalid_moves = []
+        # Calculate invalid moves
+
+
         for move in self.moves:
-            possible_moves.append(('ATTACK', self.moves.index(move)))
+            if move not in invalid_moves:
+                possible_moves.append(('ATTACK', self.moves.index(move)))
+
+        # No valid moves
+        if not possible_moves:
+            raise RuntimeError("NO VALID MOVES")
 
         return can_switch, possible_moves
 

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -297,7 +297,7 @@ class Pokemon:
 
     def set_volatile_status(self, status_key, status_value=0):
         """Set this pokemon's volatile status."""
-        if status_key in self.volatile_status:
+        if status_key in self.volatile_status and status_key != "autotomize":
             return
 
         self.volatile_status[status_key] = status_value
@@ -314,7 +314,7 @@ class Pokemon:
         return confusion_move.calculate_damage(self, self, True)
 
     def get_weight(self):
-        """Get this pokemon's weight in KG."""
+        """Return this pokemon's weight in KG."""
         return self.weight
 
 def default_boosts():

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -76,6 +76,7 @@ class Pokemon:
         self.types = POKEMON_DATA[self.name]["types"]
         self.base_stats = POKEMON_DATA[self.name]["baseStats"]
         self.dex_num = POKEMON_DATA[self.name]["num"]
+        self.weight = POKEMON_DATA[self.name]["weightkg"]
         self.status = None
         self.status_turns = 0
         self.evs = evs
@@ -313,8 +314,8 @@ class Pokemon:
         return confusion_move.calculate_damage(self, self, True)
 
     def get_weight(self):
-        """Get this pokemon's weight."""
-        raise NotImplementedError("DOOT")
+        """Get this pokemon's weight in KG."""
+        return self.weight
 
 def default_boosts():
     """Generate dictionary with default boost levels."""

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -261,8 +261,16 @@ class Pokemon:
         invalid_moves = set()
         # Calculate invalid moves
         if "torment" in self.volatile_status:
+            # Cannot repeat same move under torment
             invalid_moves.add(self.volatile_status["torment"])
+        if "taunt" in self.volatile_status:
+            # Cannot use status moves under taunt
+            for move in self.moves:
+                if move.category == "Status":
+                    invalid_moves.add(move)
 
+
+        # Based on invalid moves, generate possible moves
         for move in self.moves:
             if move not in invalid_moves:
                 possible_moves.append(('ATTACK', self.moves.index(move)))

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -321,6 +321,20 @@ class Pokemon:
         # User's weight cannot go below 0.1 KG
         return max(mod_weight, 0.1)
 
+    def apply_endofturn_volatile_status_effects(self):
+        """
+        Apply end-of-turn effects from volatile statusses.
+
+        If a volatile status activates its effect at the end of a turn,
+        its effect is applied here.
+        """
+        hp_change = 0
+        if "aquaring" in self.volatile_status:
+            hp_change += floor(self.max_hp * 1/16)
+
+        self.current_hp += hp_change
+        self.current_hp = min((self.current_hp, self.max_hp))
+
 
 def default_boosts():
     """Generate dictionary with default boost levels."""

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -296,6 +296,16 @@ class Pokemon:
 
         self.volatile_status[status_key] = status_value
 
+    def confusion_damage(self):
+        """Calculate confusion damage."""
+        confusion_config = {
+            "type": None,
+            "category": "Physical",
+            "basePower": 40
+        }
+        confusion_move = generate_move(confusion_config)
+
+        return confusion_move.calculate_damage(self, self, True)
 
 def default_boosts():
     """Generate dictionary with default boost levels."""

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -312,6 +312,10 @@ class Pokemon:
 
         return confusion_move.calculate_damage(self, self, True)
 
+    def get_weight(self):
+        """Get this pokemon's weight."""
+        raise NotImplementedError("DOOT")
+
 def default_boosts():
     """Generate dictionary with default boost levels."""
     boost_dict = {}

--- a/pokemon_helpers/pokemon.py
+++ b/pokemon_helpers/pokemon.py
@@ -315,7 +315,11 @@ class Pokemon:
 
     def get_weight(self):
         """Return this pokemon's weight in KG."""
-        return self.weight
+        autotomize_modifier = self.volatile_status.get("autotomize", 0)
+        mod_weight = self.weight - 100 * autotomize_modifier
+
+        # User's weight cannot go below 0.1 KG
+        return max(mod_weight, 0.1)
 
 def default_boosts():
     """Generate dictionary with default boost levels."""

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -323,6 +323,7 @@ def test_volatile_status():
     test_vs_torment()
     test_vs_flinch_taunt()
     test_vs_attract()
+    test_duration_vs()
 
 
 def test_vs_switch():
@@ -510,6 +511,24 @@ def test_vs_attract():
             num_attract += 1
 
     assert num_attract > 0
+
+
+def test_duration_vs():
+    """Test that volatile statuses with specified durations only last that long."""
+    player1 = PokemonAgent([Pokemon(name="ninjask", moves=["healblock"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["growl"])])
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+
+    player_move = ("ATTACK", 0)
+    p_eng.run_single_turn(player_move, player_move, player1, player2)
+    # Has not worn off
+    assert p_eng.game_state["player2"]["active"].volatile_status.get("healblock")
+    for _ in range(5):
+        p_eng.run_single_turn(player_move, player_move, player1, player2)
+
+    assert not p_eng.game_state["player2"]["active"].volatile_status
 
 
 test_run()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -360,13 +360,13 @@ def test_primary_vs():
 
     # Check volatile status applied
     assert p_eng.game_state["player2"]["active"].volatile_status
-    assert p_eng.game_state["player2"]["active"].volatile_status["smackdown"] == 0
+    assert p_eng.game_state["player2"]["active"].volatile_status["smackdown"]["counter"] == 0
     assert p_eng.game_state["player2"]["active"].volatile_status["uproar"] == 1
 
     # Increment counter
     p_eng.run_single_turn(player_move, player_move, player1, player2)
     assert p_eng.game_state["player2"]["active"].volatile_status
-    assert p_eng.game_state["player2"]["active"].volatile_status["smackdown"] == 1
+    assert p_eng.game_state["player2"]["active"].volatile_status["smackdown"]["counter"] == 1
     assert p_eng.game_state["player2"]["active"].volatile_status["uproar"] == 2
 
 

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -531,6 +531,23 @@ def test_duration_vs():
     assert not p_eng.game_state["player2"]["active"].volatile_status
 
 
+def test_vs_endofturn_effects():
+    """Test that end of turn effects are applied."""
+    player1 = PokemonAgent([Pokemon(name="ninjask", moves=["growl"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["aquaring"])])
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+    p_eng.game_state["player2"]["active"].current_hp = 1
+
+    player_move = ("ATTACK", 0)
+    p_eng.run_single_turn(player_move, player_move, player1, player2)
+
+    # Aquaring heals
+    assert p_eng.game_state["player2"]["active"].volatile_status.get("aquaring")
+    assert p_eng.game_state["player2"]["active"].current_hp > 1
+
+
 test_run()
 test_run_multiple_moves()
 test_run_multiple_pokemon()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -324,6 +324,7 @@ def test_volatile_status():
     test_vs_flinch_taunt()
     test_vs_attract()
     test_duration_vs()
+    test_vs_endofturn_effects()
 
 
 def test_vs_switch():

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -319,6 +319,7 @@ def test_volatile_status():
     test_substitute_vs()
     test_lockedmove_vs()
     test_clear_1turn_vs()
+    test_clear_2turn_vs()
 
 
 def test_vs_switch():
@@ -425,6 +426,27 @@ def test_lockedmove_vs():
     assert p_eng.game_state["player1"]["active"].volatile_status["lockedmove"]["move"] == \
         p_eng.game_state["player1"]["active"].moves[0]
 
+
+def test_clear_2turn_vs():
+    """Test that certain volatile statuses are cleared at the end of 2 turns."""
+    player1 = PokemonAgent([Pokemon(name="regigigas", moves=["laserfocus"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["blastburn"])])
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+
+    # Neither laser focus nor blast burn cleared
+    player_move = ("ATTACK", 0)
+    p_eng.run_single_turn(player_move, player_move, player1, player2)
+    assert p_eng.game_state["player1"]["active"].volatile_status
+    assert "laserfocus" in p_eng.game_state["player1"]["active"].volatile_status
+    assert p_eng.game_state["player2"]["active"].volatile_status
+    assert "mustrecharge" in p_eng.game_state["player2"]["active"].volatile_status
+
+    # Cleared after 2 turns
+    p_eng.run_single_turn(player_move, player_move, player1, player2)
+    assert not p_eng.game_state["player1"]["active"].volatile_status
+    assert not p_eng.game_state["player2"]["active"].volatile_status
 
 test_run()
 test_run_multiple_moves()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -321,6 +321,7 @@ def test_volatile_status():
     test_clear_1turn_vs()
     test_clear_2turn_vs()
     test_vs_torment()
+    test_vs_attack()
 
 
 def test_vs_switch():
@@ -474,6 +475,21 @@ def test_vs_torment():
     p_eng.run_single_turn(attack1, attack1, player1, player2)
     assert p_eng.game_state["player1"]["active"].volatile_status["torment"] == \
         p_eng.game_state["player1"]["active"].moves[1]
+
+
+def test_vs_attack():
+    """Test that volatile status accounted for n attacking."""
+    player1 = PokemonAgent([Pokemon(name="ninjask", moves=["synthesis", "softboiled"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["softboiled"])])
+    player1.team[0].volatile_status["taunt"] = 0
+    player2.team[0].volatile_status["flinch"] = 0
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+
+    # Cannot attack when flinching
+    assert p_eng.attack("player1", player1.team[0].moves[0]) is None
+    assert p_eng.attack("player2", player2.team[0].moves[0]) is None
 
 
 test_run()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -348,7 +348,7 @@ def test_vs_switch():
 
 def test_primary_vs():
     """Test that primary volatileStatus is set properly."""
-    player1 = PokemonAgent([Pokemon(name="spinda", moves=["confuseray"])])
+    player1 = PokemonAgent([Pokemon(name="spinda", moves=["smackdown"])])
     player2 = PokemonAgent([Pokemon(name="spinda", moves=["uproar"], nature="timid")])
 
     p_eng = PokemonEngine()
@@ -359,13 +359,13 @@ def test_primary_vs():
 
     # Check volatile status applied
     assert p_eng.game_state["player2"]["active"].volatile_status
-    assert p_eng.game_state["player2"]["active"].volatile_status["confusion"] == 0
+    assert p_eng.game_state["player2"]["active"].volatile_status["smackdown"] == 0
     assert p_eng.game_state["player2"]["active"].volatile_status["uproar"] == 1
 
     # Increment counter
     p_eng.run_single_turn(player_move, player_move, player1, player2)
     assert p_eng.game_state["player2"]["active"].volatile_status
-    assert p_eng.game_state["player2"]["active"].volatile_status["confusion"] == 1
+    assert p_eng.game_state["player2"]["active"].volatile_status["smackdown"] == 1
     assert p_eng.game_state["player2"]["active"].volatile_status["uproar"] == 2
 
 

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -318,6 +318,7 @@ def test_volatile_status():
     test_primary_vs()
     test_substitute_vs()
     test_lockedmove_vs()
+    test_clear_1turn_vs()
 
 
 def test_vs_switch():
@@ -363,6 +364,26 @@ def test_primary_vs():
     assert p_eng.game_state["player2"]["active"].volatile_status
     assert p_eng.game_state["player2"]["active"].volatile_status["confusion"] == 1
     assert p_eng.game_state["player2"]["active"].volatile_status["uproar"] == 2
+
+
+def test_clear_1turn_vs():
+    """Test that certain volatile statuses are cleared at the end of a turn."""
+    player1 = PokemonAgent([Pokemon(name="regigigas", moves=["banefulbunker"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["uproar"])])
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+
+    # Baneful bunker cleared after turn, uproar is not
+    player_move = ("ATTACK", 0)
+    p_eng.run_single_turn(player_move, player_move, player1, player2)
+    assert not p_eng.game_state["player1"]["active"].volatile_status
+    assert p_eng.game_state["player2"]["active"].volatile_status
+
+    # So is flinch
+    p_eng.game_state["player1"]["active"].volatile_status["flinch"] = 0
+    p_eng.run_single_turn(player_move, player_move, player1, player2)
+    assert not p_eng.game_state["player1"]["active"].volatile_status
 
 
 def test_substitute_vs():

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -475,7 +475,6 @@ def test_vs_torment():
     assert p_eng.game_state["player1"]["active"].volatile_status["torment"] == \
         p_eng.game_state["player1"]["active"].moves[1]
 
-    assert False == True
 
 test_run()
 test_run_multiple_moves()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -320,6 +320,7 @@ def test_volatile_status():
     test_lockedmove_vs()
     test_clear_1turn_vs()
     test_clear_2turn_vs()
+    test_vs_torment()
 
 
 def test_vs_switch():
@@ -447,6 +448,30 @@ def test_clear_2turn_vs():
     p_eng.run_single_turn(player_move, player_move, player1, player2)
     assert not p_eng.game_state["player1"]["active"].volatile_status
     assert not p_eng.game_state["player2"]["active"].volatile_status
+
+
+def test_vs_torment():
+    """Test that torment works properly."""
+    player1 = PokemonAgent([Pokemon(name="ninjask", moves=["synthesis", "softboiled"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["torment"])])
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+    attack0 = ("ATTACK", 0)
+    attack1 = ("ATTACK", 1)
+
+    # Initially Torment is None
+    p_eng.run_single_turn(attack0, attack0, player1, player2)
+    assert p_eng.game_state["player1"]["active"].volatile_status
+    assert "torment" in p_eng.game_state["player1"]["active"].volatile_status
+
+    # Torment is first move
+    p_eng.run_single_turn(attack0, attack0, player1, player2)
+    print("\t", p_eng.game_state["player1"]["active"].volatile_status["torment"])
+    assert p_eng.game_state["player1"]["active"].volatile_status["torment"] == \
+        p_eng.game_state["player1"]["active"].moves[0]
+
+    assert False == True
 
 test_run()
 test_run_multiple_moves()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -321,7 +321,8 @@ def test_volatile_status():
     test_clear_1turn_vs()
     test_clear_2turn_vs()
     test_vs_torment()
-    test_vs_attack()
+    test_vs_flinch_taunt()
+    test_vs_attract()
 
 
 def test_vs_switch():
@@ -477,7 +478,7 @@ def test_vs_torment():
         p_eng.game_state["player1"]["active"].moves[1]
 
 
-def test_vs_attack():
+def test_vs_flinch_taunt():
     """Test that volatile status accounted for n attacking."""
     player1 = PokemonAgent([Pokemon(name="ninjask", moves=["synthesis", "softboiled"])])
     player2 = PokemonAgent([Pokemon(name="spinda", moves=["softboiled"])])
@@ -487,9 +488,28 @@ def test_vs_attack():
     p_eng = PokemonEngine()
     p_eng.initialize_battle(player1, player2)
 
-    # Cannot attack when flinching
+    # Cannot use status when taunted
     assert p_eng.attack("player1", player1.team[0].moves[0]) is None
+    # Cannot attack while Flinching
     assert p_eng.attack("player2", player2.team[0].moves[0]) is None
+
+
+def test_vs_attract():
+    """Check that attract works."""
+    player1 = PokemonAgent([Pokemon(name="ninjask", moves=["synthesis", "softboiled"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["softboiled"])])
+
+    player1.team[0].volatile_status["attract"] = 0
+
+    p_eng = PokemonEngine()
+    p_eng.initialize_battle(player1, player2)
+
+    num_attract = 0
+    for _ in range(500):
+        if p_eng.attack("player1", player1.team[0].moves[0]) is None:
+            num_attract += 1
+
+    assert num_attract > 0
 
 
 test_run()

--- a/tests/engine_tests/pokemon_engine_test.py
+++ b/tests/engine_tests/pokemon_engine_test.py
@@ -453,7 +453,7 @@ def test_clear_2turn_vs():
 def test_vs_torment():
     """Test that torment works properly."""
     player1 = PokemonAgent([Pokemon(name="ninjask", moves=["synthesis", "softboiled"])])
-    player2 = PokemonAgent([Pokemon(name="spinda", moves=["torment"])])
+    player2 = PokemonAgent([Pokemon(name="spinda", moves=["torment", "earthquake"])])
 
     p_eng = PokemonEngine()
     p_eng.initialize_battle(player1, player2)
@@ -467,9 +467,13 @@ def test_vs_torment():
 
     # Torment is first move
     p_eng.run_single_turn(attack0, attack0, player1, player2)
-    print("\t", p_eng.game_state["player1"]["active"].volatile_status["torment"])
     assert p_eng.game_state["player1"]["active"].volatile_status["torment"] == \
         p_eng.game_state["player1"]["active"].moves[0]
+
+    # Torment is second move
+    p_eng.run_single_turn(attack1, attack1, player1, player2)
+    assert p_eng.game_state["player1"]["active"].volatile_status["torment"] == \
+        p_eng.game_state["player1"]["active"].moves[1]
 
     assert False == True
 

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -394,6 +394,16 @@ def test_healing():
     assert ivysaur.current_hp == ivysaur.max_hp
 
 
+def test_autotomize():
+    """Test that automotize works."""
+    autotomize = BaseMove(**MOVE_DATA["autotomize"])
+    ivysaur = Pokemon(name="ivysaur", moves=["synthesis"])
+    aggron = Pokemon(name="aggron", moves=["synthesis"])
+
+    ivysaur.get_weight()
+    aggron.get_weight()
+
+
 test_base_init()
 test_brakcet_op()
 test_calculate_damage()
@@ -406,3 +416,4 @@ test_boosting_moves()
 test_volatile_status()
 test_generate_move()
 test_healing()
+test_autotomize()

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -41,6 +41,29 @@ def test_calculate_damage():
     assert damage == 78
 
 
+def test_calculate_damage_laserfocus():
+    """Test that Laser Focus guarantees a crit."""
+    tackle = BaseMove(**MOVE_DATA["tackle"])
+    exploud = Pokemon(name="exploud", moves=["return"])
+    floatzel = Pokemon(name="floatzel", moves=["shadowball"])
+
+    # TODO: Break out testing logic to be no_crits and no_variance
+    num_runs = 500
+    non_laserfocus_dmg = 0
+    laserfocus_dmg = 0
+    for _ in range(num_runs):
+        damage, _ = tackle.calculate_damage(exploud, floatzel, True)
+        non_laserfocus_dmg += damage
+
+    exploud.volatile_status["laserfocus"] = 0
+    for _ in range(num_runs):
+        damage, _ = tackle.calculate_damage(exploud, floatzel)
+        laserfocus_dmg += damage
+
+    # Proxy for not actually having a way to enforce no range
+    assert non_laserfocus_dmg * 1.3 < laserfocus_dmg
+
+
 def test_calculate_modifier():
     """Test that modifier is calculated properly."""
     tackle = BaseMove(**MOVE_DATA["tackle"])
@@ -374,6 +397,7 @@ def test_healing():
 test_base_init()
 test_brakcet_op()
 test_calculate_damage()
+test_calculate_damage_laserfocus()
 test_calculate_modifier()
 test_check_hit()
 test_ohko_move()

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -415,6 +415,7 @@ def test_autotomize_increment():
     autotomize.apply_volatile_status(aggron, ivysaur)
     assert aggron.volatile_status["autotomize"] == 2
 
+
 def test_autotomize_effect():
     """Test that aututomize reduces weight."""
     autotomize = VolatileStatusMove(**MOVE_DATA["autotomize"])
@@ -426,6 +427,12 @@ def test_autotomize_effect():
 
     autotomize.apply_volatile_status(aggron, ivysaur)
     assert aggron.get_weight() == og_weight - 100
+
+    autotomize.apply_volatile_status(aggron, ivysaur)
+    assert aggron.get_weight() == og_weight - 200
+
+    autotomize.apply_volatile_status(ivysaur, aggron)
+    assert ivysaur.get_weight() == 0.1
 
 
 test_base_init()

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -278,7 +278,6 @@ def test_primary_vs_edges():
     assert defend.volatile_status == {}
 
 
-
 def test_substitute_vs():
     """Make sure substitute is handled properly."""
     exploud = Pokemon(name="exploud", moves=["substitute"])

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -396,13 +396,15 @@ def test_healing():
 
 def test_autotomize():
     """Test that automotize works."""
-    autotomize = BaseMove(**MOVE_DATA["autotomize"])
+    autotomize = VolatileStatusMove(**MOVE_DATA["autotomize"])
     ivysaur = Pokemon(name="ivysaur", moves=["synthesis"])
     aggron = Pokemon(name="aggron", moves=["synthesis"])
+    og_weight = aggron.get_weight()
 
-    ivysaur.get_weight()
-    aggron.get_weight()
+    assert og_weight > ivysaur.get_weight()
 
+    autotomize.apply_volatile_status(aggron, ivysaur)
+    assert aggron.get_weight == og_weight - 100
 
 test_base_init()
 test_brakcet_op()

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -423,14 +423,18 @@ def test_autotomize_effect():
     aggron = Pokemon(name="aggron", moves=["synthesis"])
     og_weight = aggron.get_weight()
 
+    # Aggron heavier than Ivysaur
     assert og_weight > ivysaur.get_weight()
 
+    # First autotomize reduces weight by 100
     autotomize.apply_volatile_status(aggron, ivysaur)
     assert aggron.get_weight() == og_weight - 100
 
+    # Repeated use of Autotomize continues to lower weight
     autotomize.apply_volatile_status(aggron, ivysaur)
     assert aggron.get_weight() == og_weight - 200
 
+    # Weight cannot go lower than 0.1 KG
     autotomize.apply_volatile_status(ivysaur, aggron)
     assert ivysaur.get_weight() == 0.1
 

--- a/tests/misc_tests/moves_test.py
+++ b/tests/misc_tests/moves_test.py
@@ -396,6 +396,27 @@ def test_healing():
 
 def test_autotomize():
     """Test that automotize works."""
+    test_autotomize_increment()
+    test_autotomize_effect()
+
+
+def test_autotomize_increment():
+    """Test that autotomize increments the counter when used repeatedly."""
+    autotomize = VolatileStatusMove(**MOVE_DATA["autotomize"])
+    aggron = Pokemon(name="aggron", moves=["synthesis"])
+    ivysaur = Pokemon(name="ivysaur", moves=["synthesis"])
+
+    assert "autotomize" not in aggron.volatile_status
+    autotomize.apply_volatile_status(aggron, ivysaur)
+
+    assert "autotomize" in aggron.volatile_status
+    assert aggron.volatile_status["autotomize"] == 1
+
+    autotomize.apply_volatile_status(aggron, ivysaur)
+    assert aggron.volatile_status["autotomize"] == 2
+
+def test_autotomize_effect():
+    """Test that aututomize reduces weight."""
     autotomize = VolatileStatusMove(**MOVE_DATA["autotomize"])
     ivysaur = Pokemon(name="ivysaur", moves=["synthesis"])
     aggron = Pokemon(name="aggron", moves=["synthesis"])
@@ -404,7 +425,8 @@ def test_autotomize():
     assert og_weight > ivysaur.get_weight()
 
     autotomize.apply_volatile_status(aggron, ivysaur)
-    assert aggron.get_weight == og_weight - 100
+    assert aggron.get_weight() == og_weight - 100
+
 
 test_base_init()
 test_brakcet_op()

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -221,6 +221,14 @@ def test_possible_moves():
     assert moves
     assert len(moves) == 2
 
+    # Test torment
+    pkmn.volatile_status["torment"] = pkmn.moves[0]
+    poke_can_switch, moves = pkmn.possible_moves()
+    assert poke_can_switch
+    assert moves
+    assert len(moves) == 1
+    assert moves[0] == pkmn.moves[1]
+
 
 def status_dmg_test():
     """Test Status Damage applied correctly."""

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -244,6 +244,14 @@ def test_possible_moves():
     assert len(moves) == 1
     assert moves[0] == ("ATTACK", 0)
 
+    # Heal Block prevents healing moves
+    pkmn = Pokemon(name="spinda", moves=["softboiled", "tackle"])
+    pkmn.volatile_status["healblock"] = 0
+    _, moves = pkmn.possible_moves()
+    assert moves
+    assert len(moves) == 1
+    assert moves[0] == ("ATTACK", 1)
+
 
 def status_dmg_test():
     """Test Status Damage applied correctly."""

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -282,6 +282,25 @@ def test_confusion_damage():
     assert damage == 35
     assert not critical_hit
 
+
+def test_endofturn_volatile_status_effects():
+    """Test that end of turn vs effects are properly applied."""
+    pkmn = Pokemon(name="spinda", moves=["tackle", "watergun"])
+    pkmn.current_hp = 1
+
+    # If no VS, HP does not change
+    pkmn.apply_endofturn_volatile_status_effects()
+    assert pkmn.current_hp == 1
+
+    # If aquaring, HP changes
+    pkmn.volatile_status = {
+        "aquaring": 1
+    }
+    pkmn.apply_endofturn_volatile_status_effects()
+    print(pkmn.current_hp, pkmn.max_hp)
+    assert pkmn.current_hp == 17
+
+
 test_init()
 test_param_validation()
 test_stats_calculation()
@@ -293,3 +312,4 @@ test_possible_moves()
 status_dmg_test()
 test_set_vs()
 test_confusion_damage()
+test_endofturn_volatile_status_effects()

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -229,7 +229,7 @@ def test_possible_moves():
     assert len(moves) == 1
     assert moves[0] == ("ATTACK", 1)
 
-    # Only 1 move, should raise a NotImplementedError
+    # No Vamid Moves, should raise a NotImplementedError
     pkmn.moves = pkmn.moves[:1]
     try:
         _, _ = pkmn.possible_moves()

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -214,7 +214,7 @@ def test_get_method():
 
 def test_possible_moves():
     """Make sure possible_moves works properly."""
-    pkmn = Pokemon(name="spinda", moves=["tackle", "watergun"], level=50)
+    pkmn = Pokemon(name="spinda", moves=["tackle", "teeterdance"], level=50)
     poke_can_switch, moves = pkmn.possible_moves()
 
     assert poke_can_switch
@@ -223,19 +223,26 @@ def test_possible_moves():
 
     # Test torment where pokemon can make more than 1 move
     pkmn.volatile_status["torment"] = pkmn.moves[0]
-    poke_can_switch, moves = pkmn.possible_moves()
-    assert poke_can_switch
+    _, moves = pkmn.possible_moves()
     assert moves
     assert len(moves) == 1
     assert moves[0] == ("ATTACK", 1)
 
-    # No Vamid Moves, should raise a NotImplementedError
+    # No Valid Moves, should raise a NotImplementedError
     pkmn.moves = pkmn.moves[:1]
     try:
         _, _ = pkmn.possible_moves()
         assert False
     except NotImplementedError:
         pass
+
+    # Taunt does not allow pokemon to use status moves
+    pkmn = Pokemon(name="spinda", moves=["tackle", "teeterdance"], level=50)
+    pkmn.volatile_status["taunt"] = 0
+    _, moves = pkmn.possible_moves()
+    assert moves
+    assert len(moves) == 1
+    assert moves[0] == ("ATTACK", 0)
 
 
 def status_dmg_test():

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -221,14 +221,16 @@ def test_possible_moves():
     assert moves
     assert len(moves) == 2
 
-    # Test torment
+    # Test torment where pokemon can make more than 1 move
     pkmn.volatile_status["torment"] = pkmn.moves[0]
     poke_can_switch, moves = pkmn.possible_moves()
     assert poke_can_switch
     assert moves
     assert len(moves) == 1
-    assert moves[0] == pkmn.moves[1]
+    assert moves[0] == ("ATTACK", 1)
 
+    pkmn.moves = pkmn.moves[:1]
+    
 
 def status_dmg_test():
     """Test Status Damage applied correctly."""

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -274,8 +274,6 @@ def test_confusion_damage():
     assert damage == 35
     assert not critical_hit
 
-    assert False
-
 test_init()
 test_param_validation()
 test_stats_calculation()

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -229,8 +229,14 @@ def test_possible_moves():
     assert len(moves) == 1
     assert moves[0] == ("ATTACK", 1)
 
+    # Only 1 move, should raise a NotImplementedError
     pkmn.moves = pkmn.moves[:1]
-    
+    try:
+        _, _ = pkmn.possible_moves()
+        assert False
+    except NotImplementedError:
+        pass
+
 
 def status_dmg_test():
     """Test Status Damage applied correctly."""

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -297,8 +297,12 @@ def test_endofturn_volatile_status_effects():
         "aquaring": 1
     }
     pkmn.apply_endofturn_volatile_status_effects()
-    print(pkmn.current_hp, pkmn.max_hp)
     assert pkmn.current_hp == 17
+
+    # HP change does not go over Max HP
+    pkmn.current_hp = 260
+    pkmn.apply_endofturn_volatile_status_effects()
+    assert pkmn.current_hp == pkmn.max_hp
 
 
 test_init()

--- a/tests/misc_tests/pokemon_test.py
+++ b/tests/misc_tests/pokemon_test.py
@@ -265,6 +265,17 @@ def test_set_vs():
     assert pkmn.volatile_status == {'doot': 8}
 
 
+def test_confusion_damage():
+    """Test damage done in confusion."""
+    pkmn = Pokemon(name="spinda", moves=["tackle", "watergun"])
+
+    damage, critical_hit = pkmn.confusion_damage()
+
+    assert damage == 35
+    assert not critical_hit
+
+    assert False
+
 test_init()
 test_param_validation()
 test_stats_calculation()
@@ -275,3 +286,4 @@ test_get_method()
 test_possible_moves()
 status_dmg_test()
 test_set_vs()
+test_confusion_damage()


### PR DESCRIPTION
Addresses Issue #136 

## Updates
Adds the following Volatile Statuses to the Engine
- Aqua Ring
- Attract
- Automotize
- Confusion
- Flinch
- Heal Block
- Laser Focus
- Substitute
- Taunt
- Torment

## Test Cases
`engine_tests/pokemon_engine_test.py`
- Baneful Bunker (single-turn volatile status) is used, volatile status is cleared at the end of the turn
- Laser Focus (2-turn volatile status) is used, volatile status is not cleared until the end of the next turn
- A pokemon under Torment has the move updated each turn
- If a Pokemon has Flinch as a Volatile status, it does not attack (attack returns `None`)
- A pokemon with the Attract volatile status will be immobilized
- Volatile statuses that last a certain number of turns (ex: Heal Block) only last for that long
- Volatile Statuses that activate at the end of a turn (ex: Aqua Ring) have their effects applied at the end of a turn
`misc_tests/moves_test.py`
- A pokemon with Laser Focus as its volatile status will always get a critical hit
- Moves with Volatile Statuses as secondary effects apply those appropriately
- Autotomize correctly lowers the weight of a pokemon
`misc_tests/pokemon_test.py`
- When a Pokemon cannot make a move under Torment, it struggles (raises `NotImplementedError`)
- Taunt prevents the use of status moves
- Heal Block prevents the use of healing moves
- Confusion Damage is calculated properly
- The method to set volatile statuses works correctly
- End-of-turn volatile status effects work properly